### PR TITLE
Cleanup - Conditionally hide some admin tabs

### DIFF
--- a/chart/slackernews/README.md
+++ b/chart/slackernews/README.md
@@ -57,7 +57,47 @@ if you are using the built-in `kind` cluster from `make dev-cluster`, add a Node
 Then you can open slackernews on localhost:3000 (you still need an ngrok or other tunnel to log in, etc), and you can
 access postgres locally on port 5432.
 
-If you are signing in for the first time, you will need to flip the admin bit for your user. (instructions coming soon)
+## Giving yourself Admin Privileges
+
+
+### With a helm value
+
+To get access to admin functionality, your user needs the `is_super_admin` column set to true in the database. 
+The quickest way to do this is to pass in an email address in `slackernews.adminUserEmails`.
+
+```
+    --set slackernews.adminUserEmails=<your email>
+```
+
+Be sure to use the email associated with the slack account you'll use to log in to slackernews.
+
+### With an env var
+
+You can also add yourself to the admins list by modifying a nextjs .env file
+
+```env
+SLACKERNEWS_ADMIN_USER_EMAILS=<your email>
+```
+
+Again, be sure to use the email associated with the slack account you'll use to log in to slackernews.
+
+### By modifying the database
+
+Once you have signed in for the first time, you can flip admin bit for your user with a database query. 
+These instructions are for a local kind cluster exposing postgres on 5432. 
+
+```shell
+psql --host 127.0.0.1 \slackernews --user slackernews \
+    -c "UPDATE slackernews_user SET is_super_admin = TRUE WHERE email_address = '<your email>'"
+```
+
+You can also create a port-forward with kubectl to make the above command work for a remote cluster:
+
+```shell
+kubectl port-forward svc/postgres 5432:5432
+```
+
+From there, you can log in navigate to `/admin` - you shouldn't need to [configure slack](../../CONTRIBUTING.md#configuring-a-slack-app) if you already passed credentials as helm values.
 
 ## Releasing
 

--- a/chart/slackernews/templates/slackernews-deployment.yaml
+++ b/chart/slackernews/templates/slackernews-deployment.yaml
@@ -56,6 +56,8 @@ spec:
                 name: "{{ if .Values.slack.existingSecretName }}{{ .Values.slack.existingSecretName }}{{ else }}slackernews-slack{{ end }}"
           - name: REPLICATED_ENABLED
             value: "true"
+          - name: REPLICATED_KOTS_MANAGED
+            value: {{ .Values.replicated.isKOTSManaged  | quote }}
           - name: INSTALL_METHOD
             value: helm
           - name: SLACKERNEWS_ADMIN_USER_EMAILS

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -27,6 +27,7 @@ spec:
     replicated:
       enabled: false
       preflights: false
+      isKOTSManaged: true
     service:
       tls:
         enabled: true

--- a/slackernews/components/admin-layout.js
+++ b/slackernews/components/admin-layout.js
@@ -7,7 +7,14 @@ import getConfig from 'next/config';
 
 const { publicRuntimeConfig } = getConfig();
 
-export default function Layout({ children, currentPage, isReplicatedEnabled, isUpdateAvailable, }) {
+export default function Layout({
+  children,
+  currentPage,
+  isReplicatedEnabled,
+  isUpdateAvailable,
+  isKOTSManaged,
+  showChromePluginTab
+}) {
 
   return (
     <>
@@ -79,6 +86,7 @@ export default function Layout({ children, currentPage, isReplicatedEnabled, isU
               </li>
               </>
               }
+              {isKOTSManaged &&
               <li>
                 <Link href="/admin/admin-console" className={`nav-link ${
                       currentPage === "admin-console" ? "active" : "link-dark"
@@ -87,6 +95,7 @@ export default function Layout({ children, currentPage, isReplicatedEnabled, isU
                     Admin Console
                 </Link>
               </li>
+              }
               <li>
                 <Link href="/admin/admin-notifications" className={`nav-link ${
                       currentPage === "admin-notifications"
@@ -113,6 +122,7 @@ export default function Layout({ children, currentPage, isReplicatedEnabled, isU
                     Slack
                 </Link>
               </li>
+              {showChromePluginTab &&
               <li className="nav-item">
                 <Link href="/admin/chrome-plugin" className={`nav-link ${
                       currentPage === "chrome-plugin" ? "active" : "link-dark"
@@ -121,6 +131,7 @@ export default function Layout({ children, currentPage, isReplicatedEnabled, isU
                     Chrome Plugin
                 </Link>
               </li>
+              }
             </ul>
           </div>
           <main style={{ paddingLeft: "24px", width: "100%" }}>{children}</main>

--- a/slackernews/lib/env-config.ts
+++ b/slackernews/lib/env-config.ts
@@ -1,0 +1,17 @@
+import {Env} from "@next/env";
+
+export type EnvConfig = {
+    isReplicatedEnabled: boolean;
+    isKOTSManaged: boolean;
+    showChromePluginTab: boolean;
+}
+
+function envConfig(): EnvConfig {
+    return {
+        isReplicatedEnabled: process.env.REPLICATED_ENABLED === "true",
+        isKOTSManaged: process.env.REPLICATED_KOTS_MANAGED === "true",
+        showChromePluginTab: process.env.SHOW_CHROME_PLUGIN_TAB === "true",
+    }
+};
+export default envConfig
+

--- a/slackernews/pages/admin/admin-console.js
+++ b/slackernews/pages/admin/admin-console.js
@@ -2,6 +2,7 @@ import AdminLayout from "../../components/admin-layout";
 import React from 'react';
 import { loadSession } from "../../lib/session";
 import cookies from 'next-cookies';
+import envConfig from "../../lib/env-config";
 
 export default function Page({ isHelm, namespace , isReplicatedEnabled}) {
 
@@ -33,7 +34,11 @@ Page.getLayout = function getLayout(page) {
   console.log(page,'page')
 
   return (
-    <AdminLayout currentPage="admin-console" isReplicatedEnabled={page.props.isReplicatedEnabled}>
+    <AdminLayout currentPage="admin-console"
+                 isReplicatedEnabled={page.props.isReplicatedEnabled}
+                 isKOTSManaged={page.props.isKOTSManaged}
+                 showChromePluginTab={page.props.showChromePluginTab}
+    >
       {page}
     </AdminLayout>
   );
@@ -42,7 +47,7 @@ Page.getLayout = function getLayout(page) {
 export async function getServerSideProps(ctx) {
   const c = cookies(ctx);
   const sess = await loadSession(c.auth);  
-   const isReplicatedEnabled = process.env.REPLICATED_ENABLED === "true";
+  const {isReplicatedEnabled, isKOTSManaged, showChromePluginTab} = envConfig();
 
   if (!sess) {
     return {
@@ -76,7 +81,9 @@ export async function getServerSideProps(ctx) {
       hideDuration: true,
       isHelm: process.env["INSTALL_METHOD"] === "helm",
       namespace,
-      isReplicatedEnabled
+      isReplicatedEnabled,
+      isKOTSManaged,
+      showChromePluginTab,
     },
   };
 }

--- a/slackernews/pages/admin/admin-notifications.js
+++ b/slackernews/pages/admin/admin-notifications.js
@@ -5,6 +5,7 @@ import { loadSession } from "../../lib/session";
 import { ensureAdminNotificationChannel } from "../../lib/slack";
 import cookies from 'next-cookies';
 import { getAdminNotificationSettings } from "../../lib/param";
+import envConfig from "../../lib/env-config";
 
 export default function Page({ notificationsChannel, initialNotificationSettings, isReplicatedEnabled }) {
   const [notificationSettings, setNotificationSettings] = useState(initialNotificationSettings);
@@ -67,7 +68,11 @@ export default function Page({ notificationsChannel, initialNotificationSettings
 
 Page.getLayout = function getLayout(page) {
   return (
-    <AdminLayout currentPage="admin-notifications" isReplicatedEnabled={page.props.isReplicatedEnabled}>
+    <AdminLayout currentPage="admin-notifications"
+                 isReplicatedEnabled={page.props.isReplicatedEnabled}
+                 isKOTSManaged={page.props.isKOTSManaged}
+                 showChromePluginTab={page.props.showChromePluginTab}
+    >
       {page}
     </AdminLayout>
   );
@@ -98,14 +103,16 @@ export async function getServerSideProps(ctx) {
 
   const adminChannel = await ensureAdminNotificationChannel();
   const adminNotificationSettings = await getAdminNotificationSettings();  
-  const isReplicatedEnabled = process.env.REPLICATED_ENABLED === "true";
+  const {isReplicatedEnabled, isKOTSManaged, showChromePluginTab} = envConfig();
   return {
     props: {
       username: sess.user.name,
       hideDuration: true,
       notificationsChannel: adminChannel,
       initialNotificationSettings: adminNotificationSettings,
-      isReplicatedEnabled
+      isReplicatedEnabled,
+      isKOTSManaged,
+      showChromePluginTab,
     },
   };
 }

--- a/slackernews/pages/admin/chrome-plugin.js
+++ b/slackernews/pages/admin/chrome-plugin.js
@@ -4,11 +4,19 @@ import router, { useRouter } from 'next/router';
 import { loadSession } from "../../lib/session";
 import cookies from 'next-cookies';
 import { getChromePluginConfig } from "../../lib/param";
+import envConfig from "../../lib/env-config";
 
-export default function Page({ isEnabled, token, isReplicatedEnabled }) {
+export default function Page({isEnabled, token, showChromePluginTab}) {
   const [enabled, setEnabled] = useState(isEnabled);
   const [pluginToken, setPluginToken] = useState(token);
+
+  if (!showChromePluginTab) {
+    // don't let them go there until this feature is ready
+    router.push("/admin");
+  }
+
   return (
+
     <div className="chrome-plugin">
       <h1>Configure the SlackerNews Chrome Plugin</h1>
       <p>
@@ -29,7 +37,11 @@ export default function Page({ isEnabled, token, isReplicatedEnabled }) {
 
 Page.getLayout = function getLayout(page) {
   return (
-    <AdminLayout currentPage="chrome-plugin" isReplicatedEnabled={page.props.isReplicatedEnabled}>
+    <AdminLayout currentPage="chrome-plugin"
+                 isReplicatedEnabled={page.props.isReplicatedEnabled}
+                 showChromePluginTab={page.props.showChromePluginTab}
+                 isKOTSManaged={page.props.isKOTSManaged}
+    >
       {page}
     </AdminLayout>
   );
@@ -59,7 +71,8 @@ export async function getServerSideProps(ctx) {
   }
 
   const chromePluginConfig = await getChromePluginConfig();
-  const isReplicatedEnabled = process.env.REPLICATED_ENABLED === "true";
+  const {isReplicatedEnabled, isKOTSManaged, showChromePluginTab} = envConfig();
+
 
   return {
     props: {
@@ -67,7 +80,9 @@ export async function getServerSideProps(ctx) {
       hideDuration: true,
       isEnabled: chromePluginConfig.enabled,
       token: chromePluginConfig.token,
-      isReplicatedEnabled
+      isReplicatedEnabled,
+      isKOTSManaged,
+      showChromePluginTab,
     },
   };
 }

--- a/slackernews/pages/admin/content-mgmt.js
+++ b/slackernews/pages/admin/content-mgmt.js
@@ -6,8 +6,17 @@ import Link from 'next/link';
 import { getTotalLinkCount, getUntitledLinkCount, listTopLinks } from "../../lib/link";
 import LinkRow from "../../components/link-row";
 import { getTotalScoreCount } from "../../lib/score";
+import envConfig from "../../lib/env-config";
 
-export default function Page({ linkCount, untitledLinkCount, totalScore, renderableLinks, nextPageUrl, startCount, isReplicatedEnabled }) {
+export default function Page({
+                               linkCount,
+                               untitledLinkCount,
+                               totalScore,
+                               renderableLinks,
+                               nextPageUrl,
+                               startCount,
+                               isReplicatedEnabled
+                             }) {
 
   const onEdited = (link, newTitle) => {
     const updatedLinks = renderableLinks.map(l => {
@@ -68,7 +77,11 @@ export default function Page({ linkCount, untitledLinkCount, totalScore, rendera
 Page.getLayout = function getLayout(page) {
 
   return (
-    <AdminLayout currentPage="content-mgmt" isReplicatedEnabled={page.props.isReplicatedEnabled}>
+    <AdminLayout currentPage="content-mgmt"
+                 isReplicatedEnabled={page.props.isReplicatedEnabled}
+                 isKOTSManaged={page.props.isKOTSManaged}
+                 showChromePluginTab={page.props.showChromePluginTab}
+    >
       {page}
     </AdminLayout>
   );
@@ -111,7 +124,8 @@ export async function getServerSideProps(ctx) {
     `/?p=${parseInt(page) + 1}`
   : null;
 
-  const isReplicatedEnabled = process.env.REPLICATED_ENABLED === "true";
+  const {isReplicatedEnabled, isKOTSManaged, showChromePluginTab} = envConfig();
+
 
   return {
     props: {
@@ -124,7 +138,9 @@ export async function getServerSideProps(ctx) {
       hasNextPage: renderableLinks.length === 30,
       nextPageUrl: nextPageUrl ? nextPageUrl : "",
       startCount: (parseInt(page) - 1) * 30 + 1,
-      isReplicatedEnabled
+      isReplicatedEnabled,
+      isKOTSManaged,
+      showChromePluginTab,
     },
   };
 }

--- a/slackernews/pages/admin/departments.js
+++ b/slackernews/pages/admin/departments.js
@@ -5,6 +5,7 @@ import Table from 'react-bootstrap/Table';
 import React, { useState } from 'react';
 import { listUserGroupsFromDB } from "../../lib/link";
 import { listUserGroupsFromSlack } from "../../lib/slack";
+import envConfig from "../../lib/env-config";
 
 export default function Page({ initialDepartments ,isReplicatedEnabled}) {
   const [departments, setDepartments] = useState(initialDepartments);
@@ -46,7 +47,8 @@ export default function Page({ initialDepartments ,isReplicatedEnabled}) {
 
   return (
     <div>
-      <p>By default all active user groups show up as a departments filter. You can exclude a user group to prevent it from showing as a department filter. 
+      <p>By default all active user groups show up as a departments filter. You can exclude a user group to prevent it
+        from showing as a department filter.
       When a department filter is applied, only links submitted by the users in that group will be displayed.</p>
 
       <p>User Groups:</p>
@@ -69,7 +71,11 @@ export default function Page({ initialDepartments ,isReplicatedEnabled}) {
 
 Page.getLayout = function getLayout(page) {
   return (
-    <AdminLayout currentPage="departments" isReplicatedEnabled={page.props.isReplicatedEnabled}>
+    <AdminLayout currentPage="departments"
+                 isReplicatedEnabled={page.props.isReplicatedEnabled}
+                 isKOTSManaged={page.props.isKOTSManaged}
+                 showChromePluginTab={page.props.showChromePluginTab}
+    >
       {page}
     </AdminLayout>
   );
@@ -108,14 +114,16 @@ export async function getServerSideProps(ctx) {
       ug.isExcluded = false
     }
   });
-  const isReplicatedEnabled = process.env.REPLICATED_ENABLED === "true";
+  const {isReplicatedEnabled, isKOTSManaged, showChromePluginTab} = envConfig();
 
   return {
     props: {
       username: sess.user.name,
       hideDuration: true,
       initialDepartments: userGroupsFromSlack,
-      isReplicatedEnabled
+      isReplicatedEnabled,
+      isKOTSManaged,
+      showChromePluginTab,
     },
   };
 }

--- a/slackernews/pages/admin/index.js
+++ b/slackernews/pages/admin/index.js
@@ -2,9 +2,10 @@ import React, { useEffect, useState } from 'react';
 import cookies from 'next-cookies';
 import Layout from '../../components/layout';
 import { loadSession } from '../../lib/session';
+import envConfig from "../../lib/env-config";
 
 
-export default function Page({isReplicatedEnabled }) {
+export default function Page({isReplicatedEnabled, isKOTSManaged}) {
   return (
  <>
  </>
@@ -14,7 +15,7 @@ export default function Page({isReplicatedEnabled }) {
 
 Page.getLayout = function getLayout(page) {
   return (
-    <Layout isReplicatedEnabled={page.props.isReplicatedEnabled}>
+    <Layout isReplicatedEnabled={page.props.isReplicatedEnabled} isKOTSManaged={page.props.isKOTSManaged}>
       {page}
     </Layout>
   );
@@ -23,7 +24,7 @@ Page.getLayout = function getLayout(page) {
 export async function getServerSideProps(ctx) {
   const c = cookies(ctx);
   const sess = await loadSession(c.auth); 
-   const isReplicatedEnabled = process.env.REPLICATED_ENABLED === "true";
+  const {isReplicatedEnabled, isKOTSManaged, showChromePluginTab} = envConfig();
 
   if (!sess) {
     return {
@@ -31,7 +32,11 @@ export async function getServerSideProps(ctx) {
         permanent: false,
         destination: "/login",
       },
-      props:{isReplicatedEnabled},
+      props: {
+        isReplicatedEnabled,
+        isKOTSManaged,
+        showChromePluginTab,
+      },
     };
   }
 

--- a/slackernews/pages/admin/integrations.js
+++ b/slackernews/pages/admin/integrations.js
@@ -8,6 +8,7 @@ import Link from "next/link";
 import Toggle from "react-toggle";
 import "react-toggle/style.css"; // for ES6 modules
 import Image from "next/image";
+import envConfig from "../../lib/env-config";
 
 export default function Page({ initialIntegrations, isReplicatedEnabled }) {
   const [integrations, setIntegrations] = useState(initialIntegrations);
@@ -101,6 +102,8 @@ Page.getLayout = function getLayout(page) {
     <AdminLayout
       currentPage="integrations"
       isReplicatedEnabled={page.props.isReplicatedEnabled}
+      isKOTSManaged={page.props.isKOTSManaged}
+      showChromePluginTab={page.props.showChromePluginTab}
     >
       {page}
     </AdminLayout>
@@ -131,7 +134,8 @@ export async function getServerSideProps(ctx) {
   }
 
   const integrations = await listIntegrations();
-  const isReplicatedEnabled = process.env.REPLICATED_ENABLED === "true";
+  const {isReplicatedEnabled, isKOTSManaged, showChromePluginTab} = envConfig();
+
 
   return {
     props: {
@@ -139,6 +143,8 @@ export async function getServerSideProps(ctx) {
       hideDuration: true,
       initialIntegrations: integrations,
       isReplicatedEnabled,
+      isKOTSManaged,
+      showChromePluginTab,
     },
   };
 }

--- a/slackernews/pages/admin/integrations/[id].js
+++ b/slackernews/pages/admin/integrations/[id].js
@@ -42,7 +42,11 @@ export default function Page({ integration }) {
 
 Page.getLayout = function getLayout(page) {
   return (
-    <AdminLayout currentPage="integrations">
+    <AdminLayout currentPage="integrations"
+                 isReplicatedEnabled={page.props.isReplicatedEnabled}
+                 isKOTSManaged={page.props.isKOTSManaged}
+                 showChromePluginTab={page.props.showChromePluginTab}
+    >
       {page}
     </AdminLayout>
   );

--- a/slackernews/pages/admin/integrations/google-drive.js
+++ b/slackernews/pages/admin/integrations/google-drive.js
@@ -11,7 +11,8 @@ export default function Page({ isHelm, namespace }) {
     <>
       <h1>Google Drive</h1>
       <div>
-        <p>When enabled, SlackerNews will automatically update document titles for Google docs, sheets, slides, and forms.</p>
+        <p>When enabled, SlackerNews will automatically update document titles for Google docs, sheets, slides, and
+          forms.</p>
         <a href="https://docs.slackernews.io/integrations/google-drive">Docs</a>
         <form>
           <div className="form-group">
@@ -26,7 +27,12 @@ export default function Page({ isHelm, namespace }) {
 
 Page.getLayout = function getLayout(page) {
   return (
-    <AdminLayout currentPage="integrations">
+    <AdminLayout currentPage="integrations"
+                 isReplicatedEnabled={page.props.isReplicatedEnabled}
+                 isKOTSManaged={page.props.isKOTSManaged}
+                 showChromePluginTab={page.props.showChromePluginTab}
+    >
+
       {page}
     </AdminLayout>
   );

--- a/slackernews/pages/admin/members.js
+++ b/slackernews/pages/admin/members.js
@@ -25,6 +25,7 @@ import Form from "react-bootstrap/Form";
 import ListGroup from "react-bootstrap/ListGroup";
 import { ReplicatedClient } from "../../lib/replicated-sdk";
 import Image from "next/image";
+import envConfig from "../../lib/env-config";
 
 export default function Page({
   initialUsers,
@@ -117,7 +118,8 @@ export default function Page({
     }
   }
 
-  const onRemoveClick = async (id) => {};
+  const onRemoveClick = async (id) => {
+  };
 
   const onMakeAdminOrUserClick = async (id, isAdmin) => {
     try {
@@ -355,7 +357,7 @@ export async function getServerSideProps(ctx) {
 
   const dailyUsers = await listDailyActiveUsers();
   const monthlyUsers = await listMonthlyActiveUsers();
-  const isReplicatedEnabled = process.env.REPLICATED_ENABLED === "true";
+  const {isReplicatedEnabled, isKOTSManaged, showChromePluginTab} = envConfig();
   //TODO: Pass this value from helm chart in for non-sdk installs
   const memberCountMax = isReplicatedEnabled
     ? (await ReplicatedClient.getEntitlement("member_count_max")).value
@@ -371,6 +373,8 @@ export async function getServerSideProps(ctx) {
       hideDuration: true,
       memberCountMax: memberCountMax,
       isReplicatedEnabled,
+      isKOTSManaged,
+      showChromePluginTab,
     },
   };
 }

--- a/slackernews/pages/admin/slack.js
+++ b/slackernews/pages/admin/slack.js
@@ -4,8 +4,16 @@ import { loadSession } from "../../lib/session";
 import cookies from 'next-cookies';
 import Link from "next/link";
 import { getParam, isSlackLoadedFromEnv } from "../../lib/param";
+import envConfig from "../../lib/env-config";
 
-export default function Page({ isConfiguredInEnv, initialBotToken, initialUserToken, initialClientId, initialClientSecret, isReplicatedEnabled}) {
+export default function Page({
+  isConfiguredInEnv,
+  initialBotToken,
+  initialUserToken,
+  initialClientId,
+  initialClientSecret,
+  isReplicatedEnabled
+}) {
   const [botToken, setBotToken] = useState(initialBotToken);
   const [userToken, setUserToken] = useState(initialUserToken);
   const [clientId, setClientId] = useState(initialClientId);
@@ -86,7 +94,11 @@ export default function Page({ isConfiguredInEnv, initialBotToken, initialUserTo
 
 Page.getLayout = function getLayout(page) {
   return (
-    <AdminLayout currentPage="slack" isReplicatedEnabled={page.props.isReplicatedEnabled}>
+    <AdminLayout currentPage="slack"
+                 isReplicatedEnabled={page.props.isReplicatedEnabled}
+                 isKOTSManaged={page.props.isKOTSManaged}
+                 showChromePluginTab={page.props.showChromePluginTab}
+    >
       {page}
     </AdminLayout>
   );
@@ -119,7 +131,7 @@ export async function getServerSideProps(ctx) {
   }
 
   const isConfiguredInEnv = await isSlackLoadedFromEnv();
-  const isReplicatedEnabled = process.env.REPLICATED_ENABLED === "true";
+  const {isReplicatedEnabled, isKOTSManaged, showChromePluginTab} = envConfig();
   return {
     props: {
       username: sess ? sess.user.name : "Anomymous",
@@ -129,7 +141,9 @@ export async function getServerSideProps(ctx) {
       initialUserToken: await getParam("SlackUserToken") || "",
       initialClientId: await getParam("SlackClientId") || "",
       initialClientSecret: await getParam("SlackClientSecret") || "",
-      isReplicatedEnabled
+      isReplicatedEnabled,
+      isKOTSManaged,
+      showChromePluginTab,
     },
   };
 }

--- a/slackernews/pages/admin/support-bundle.tsx
+++ b/slackernews/pages/admin/support-bundle.tsx
@@ -4,11 +4,14 @@ import { CopyBlock, dracula } from "react-code-blocks";
 import Link from "next/link";
 import cookies from "next-cookies";
 import { loadSession } from "../../lib/session";
+import envConfig from "../../lib/env-config";
 
 export default function Page({
   isReplicatedEnabled,
+    isKOTSManaged,
 }: {
   isReplicatedEnabled: boolean;
+  isKOTSManaged: boolean;
 }) {
   const supportBundlePluginCmd = "curl https://krew.sh/support-bundle | bash";
   const collectSupportBundleCmd = "kubectl support-bundle --load-cluster-specs";
@@ -82,6 +85,8 @@ Page.getLayout = function getLayout(page: any) {
       currentPage="support"
       isUpdateAvailable={undefined}
       isReplicatedEnabled={page.props.isReplicatedEnabled}
+      isKOTSManaged={page.props.isKOTSManaged}
+      showChromePluginTab={page.props.showChromePluginTab}
     >
       {page}
     </AdminLayout>
@@ -114,11 +119,14 @@ export async function getServerSideProps(ctx: {
       };
     }
 
-    const isReplicatedEnabled = process.env.REPLICATED_ENABLED === "true";
+    const {isReplicatedEnabled, isKOTSManaged, showChromePluginTab} = envConfig();
+
 
     return {
       props: {
         isReplicatedEnabled,
+        isKOTSManaged,
+        showChromePluginTab,
       },
     };
   }

--- a/slackernews/pages/admin/updates.tsx
+++ b/slackernews/pages/admin/updates.tsx
@@ -16,6 +16,7 @@ import {
   faSpinner,
 } from "@fortawesome/free-solid-svg-icons";
 import { VersionHistory, Release } from "../../lib/replicated-sdk";
+import envConfig from "../../lib/env-config";
 
 type Updates = {
   versionLabel: string;
@@ -87,7 +88,7 @@ export default function Page({
     }, 60000); // update every minute
 
     return () => clearInterval(intervalId);
-  }, [updates]);
+  }, [updates, lastUpdatedDate]);
 
   const renderLastUpdated = () => {
     if (minutesPassed < 1) {
@@ -377,6 +378,8 @@ Page.getLayout = function getLayout(page: any) {
       currentPage="updates"
       isUpdateAvailable={undefined}
       isReplicatedEnabled={page.props.isReplicatedEnabled}
+      isKOTSManaged={page.props.isKOTSManaged}
+      showChromePluginTab={page.props.showChromePluginTab}
     >
       {page}
     </AdminLayout>
@@ -417,7 +420,8 @@ export async function getServerSideProps(ctx: {
     const upgradeCmd = await ReplicatedClient.getUpgradeCommand();
     const versionHistory = await ReplicatedClient.getVersionHistory();
 
-    const isReplicatedEnabled = process.env.REPLICATED_ENABLED === "true";
+    const {isReplicatedEnabled, isKOTSManaged, showChromePluginTab} = envConfig();
+
 
     return {
       props: {
@@ -429,6 +433,8 @@ export async function getServerSideProps(ctx: {
         upgradeCmd,
         isReplicatedEnabled,
         versionHistory,
+        isKOTSManaged,
+        showChromePluginTab,
       },
     };
   }

--- a/slackernews/pages/index.js
+++ b/slackernews/pages/index.js
@@ -9,6 +9,7 @@ import { listTopLinks } from "../lib/link";
 import { getParam } from "../lib/param";
 import { listAvailableUserGroups, listUsersInUserGroup } from "../lib/slack";
 import { sendMetrics } from "../lib/metrics/metric";
+import envConfig from "../lib/env-config";
 
 export default function Page({ renderableLinks, nextPageUrl, startCount, isSuperAdmin, isDebugMode }) {
   const onEdited = (link, newTitle) => {
@@ -88,6 +89,9 @@ export async function getServerSideProps(ctx) {
 
   await sendMetrics();
 
+  const {isReplicatedEnabled, isKOTSManaged, showChromePluginTab} = envConfig();
+
+
   return {
     props: {
       renderableLinks,
@@ -100,7 +104,9 @@ export async function getServerSideProps(ctx) {
       userId: sess ? sess.user.id : "",
       duration: duration,
       isSuperAdmin: sess ? sess.user.isSuperAdmin : false,
-      isReplicatedEnabled: process.env.REPLICATED_ENABLED === "true"
+      isReplicatedEnabled,
+      isKOTSManaged,
+      showChromePluginTab,
     },
   };
 }


### PR DESCRIPTION
Hide "Admin Console" and "Chrome Plugin" from the side nav if not enabled.

For admin console, added a new env var `REPLICATED_KOTS_MANAGED`, which should only be set when KOTS deploys the slackernews helm chart

For the Chrome Plugin, it seems like this is aspirational functionality, so hiding it until I can get more signal on if/how it's supposed to work