### PR TITLE
Content Management: fix sequelize query for postgres

### DIFF
--- a/.github/workflows/ingress.yaml
+++ b/.github/workflows/ingress.yaml
@@ -110,7 +110,7 @@ jobs:
           - { distribution: k3s, version: v1.26 }
           - { distribution: k3s, version: v1.27 }
           # - { distribution: openshift, version: v4.13.0-okd }
-          - { distribution: eks, version: v1.23 }
+          # - { distribution: eks, version: v1.23 }
           - { distribution: eks, version: v1.24 }
           - { distribution: eks, version: v1.25 }
           - { distribution: eks, version: v1.26 }

--- a/.github/workflows/ingress.yaml
+++ b/.github/workflows/ingress.yaml
@@ -110,7 +110,6 @@ jobs:
           - { distribution: k3s, version: v1.26 }
           - { distribution: k3s, version: v1.27 }
           # - { distribution: openshift, version: v4.13.0-okd }
-          # - { distribution: eks, version: v1.23 }
           - { distribution: eks, version: v1.24 }
           - { distribution: eks, version: v1.25 }
           - { distribution: eks, version: v1.26 }

--- a/slackernews/lib/link.ts
+++ b/slackernews/lib/link.ts
@@ -430,9 +430,7 @@ export async function getTotalLinkCount(): Promise<number> {
 
 export async function getUntitledLinkCount(): Promise<number> {
   return await (await Link()).count({
-    where: {
-      title: Sequelize.col('link'),
-    },
+    where: Sequelize.literal('title = link')
   });
 }
 


### PR DESCRIPTION
https://www.loom.com/share/7a8d6c4842a848dda4a4258a74e74ebb


Also ended up removing eks 1.23 from the list of CMX tests because it's no longer supported

      replicated cluster versions | grep -A4 eks
      DISTRIBUTION: eks
      • VERSIONS: 1.24, 1.25, 1.26, 1.27, 1.28
      • INSTANCE TYPES: m6i.large, m6i.xlarge, m6i.2xlarge, m6i.4xlarge, m6i.8xlarge, m7i.large, m7i.xlarge, m7i.2xlarge, m7i.4xlarge, m7i.8xlarge, m7g.large, m7g.xlarge, m7g.2xlarge, m7g.4xlarge, m7g.8xlarge
      • MAX NODES: 10
