### PR TITLE
GH actions: make replicated app configurable, fix trivy workflow

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -6,7 +6,7 @@ on:
     - "v*.*.*"
 env:
   REGISTRY: ghcr.io
-  REPLICATED_APP: slackernews
+
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -36,7 +36,7 @@ jobs:
                 type=ref,event=branch
                 type=ref,event=tag
                 type=ref,event=pr
-          images: ${{ env.REGISTRY }}/slackernews/slackernews-web
+          images: ${{ env.REGISTRY }}/${{ secrets.GHCR_NAMESPACE }}/slackernews-web
 
       - uses: int128/docker-build-cache-config-action@v1
         id: cache
@@ -83,7 +83,7 @@ jobs:
         with:
           include: 'chart/slackernews/values.yaml'
           find: '$IMAGE'
-          replace: 'proxy/slackernews/ghcr.io/slackernews/slackernews-web:${{ steps.get_version.outputs.version-without-v }}'
+          replace: 'proxy/${{ secrets.REPLICATED_APP }}/ghcr.io/${{ secrets.GHCR_NAMESPACE }}/slackernews-web:${{ steps.get_version.outputs.version-without-v }}'
           regex: false
 
       - id: package-helm-chart
@@ -111,7 +111,7 @@ jobs:
       - name: Create the unstable release
         uses: replicatedhq/action-kots-release@configurable-endpoint
         with:
-          replicated-app: "slackernews"
+          replicated-app: ${{ secrets.REPLICATED_APP }}
           replicated-api-token: ${{ secrets.REPLICATED_TOKEN }}
           replicated-api-origin: https://api.replicated.com/vendor
           yaml-dir: ./kots

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -7,30 +7,8 @@ on:
       
 env:
   REGISTRY: ghcr.io
-  REPLICATED_APP: slackernews
 
 jobs:
-  run-trivy-migrations:
-    runs-on: ubuntu-22.04
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    steps:
-      - name: Trivy Scan migrations
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: '${{ env.REGISTRY }}/slackernews/slackernews-migrations@${{ github.sha }}'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH,MEDIUM'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-        env:
-          TRIVY_USERNAME: ${{ github.actor }}
-          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: 'trivy-results.sarif'
   run-trivy-web:
     runs-on: ubuntu-22.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
@@ -38,28 +16,7 @@ jobs:
       - name: Trivy Scan web
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ env.REGISTRY }}/slackernews/slackernews-web@${{ github.sha }}'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH,MEDIUM'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-        env:
-          TRIVY_USERNAME: ${{ github.actor }}
-          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: 'trivy-results.sarif'
-  run-trivy-api:
-    runs-on: ubuntu-22.04
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    steps:
-      - name: Trivy Scan api
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: '${{ env.REGISTRY }}/slackernews/slackernews-api@${{ github.sha }}'
+          image-ref: '${{ env.REGISTRY }}/${{ secrets.GHCR_NAMESPACE }}/slackernews-web@${{ github.sha }}'
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'


### PR DESCRIPTION
I can now publish development/testing versions to a separate vendor portal account from my fork by setting

    REPLICATED_APP=slackernews-dexter-s-version
    GHCR_NAMESPACE=dexhorthy
    GHCR_PAT=...
    REPLICATED_TOKEN=...

I've added the secrets `REPLICATED_APP` and `GHCR_NAMESPACE` to the slackernews/slackernews repo (both set to `slackernews`)

    REPLICATED_APP=slackernews
    GHCR_NAMESPACE=slackernews

I also removed the trivy scan steps for migrations and api containers :+1: