### PR TITLE
GHA build, status informers, postgres, nginx, and more

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -6,7 +6,7 @@ on:
     - "v*.*.*"
 env:
   REGISTRY: ghcr.io
-  REPLICATED_APP: slackernews
+
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -36,7 +36,7 @@ jobs:
                 type=ref,event=branch
                 type=ref,event=tag
                 type=ref,event=pr
-          images: ${{ env.REGISTRY }}/slackernews/slackernews-web
+          images: ${{ env.REGISTRY }}/${{ secrets.GHCR_NAMESPACE }}/slackernews-web
 
       - uses: int128/docker-build-cache-config-action@v1
         id: cache
@@ -76,14 +76,23 @@ jobs:
         with:
           include: 'chart/slackernews/values.yaml'
           find: '$REGISTRY'
-          replace: 'images.slackernews.io'
+          replace: ${{ secrets.REPLICATED_PROXY_REGISTRY_CNAME || 'proxy.replicated.com' }}
           regex: false
+
       - name: Update the values.yaml with the image path
         uses: jacobtomlinson/gha-find-replace@v2
         with:
           include: 'chart/slackernews/values.yaml'
           find: '$IMAGE'
-          replace: 'proxy/slackernews/ghcr.io/slackernews/slackernews-web:${{ steps.get_version.outputs.version-without-v }}'
+          replace: 'proxy/${{ secrets.REPLICATED_APP }}/ghcr.io/${{ secrets.GHCR_NAMESPACE }}/slackernews-web:${{ steps.get_version.outputs.version-without-v }}'
+          regex: false
+
+      - name: Update the KOTS HelmChart CR with the image path
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          include: 'kots/slackernews-chart.yaml'
+          find: '$IMAGE'
+          replace: 'ghcr.io/${{ secrets.GHCR_NAMESPACE }}/slackernews-web:${{ steps.get_version.outputs.version-without-v }}'
           regex: false
 
       - id: package-helm-chart
@@ -111,7 +120,7 @@ jobs:
       - name: Create the unstable release
         uses: replicatedhq/action-kots-release@configurable-endpoint
         with:
-          replicated-app: "slackernews"
+          replicated-app: ${{ secrets.REPLICATED_APP }}
           replicated-api-token: ${{ secrets.REPLICATED_TOKEN }}
           replicated-api-origin: https://api.replicated.com/vendor
           yaml-dir: ./kots

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -7,30 +7,8 @@ on:
       
 env:
   REGISTRY: ghcr.io
-  REPLICATED_APP: slackernews
 
 jobs:
-  run-trivy-migrations:
-    runs-on: ubuntu-22.04
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    steps:
-      - name: Trivy Scan migrations
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: '${{ env.REGISTRY }}/slackernews/slackernews-migrations@${{ github.sha }}'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH,MEDIUM'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-        env:
-          TRIVY_USERNAME: ${{ github.actor }}
-          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: 'trivy-results.sarif'
   run-trivy-web:
     runs-on: ubuntu-22.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
@@ -38,28 +16,7 @@ jobs:
       - name: Trivy Scan web
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ env.REGISTRY }}/slackernews/slackernews-web@${{ github.sha }}'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH,MEDIUM'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-        env:
-          TRIVY_USERNAME: ${{ github.actor }}
-          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: 'trivy-results.sarif'
-  run-trivy-api:
-    runs-on: ubuntu-22.04
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    steps:
-      - name: Trivy Scan api
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: '${{ env.REGISTRY }}/slackernews/slackernews-api@${{ github.sha }}'
+          image-ref: '${{ env.REGISTRY }}/${{ secrets.GHCR_NAMESPACE }}/slackernews-web:sha-${{ github.sha }}'
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'

--- a/chart/slackernews/templates/nginx-service.yaml
+++ b/chart/slackernews/templates/nginx-service.yaml
@@ -11,11 +11,17 @@ spec:
 {{ if .Values.service.tls.enabled }}
     port: 443
     targetPort: https
+  {{- if ne .Values.nginx.service.nodePort.port nil }}
+    nodePort: {{ .Values.nginx.service.nodePort.port }}
+  {{- end }}
 {{ else }}
     port: 80
     targetPort: http
+  {{- if ne .Values.nginx.service.nodePort.port nil }}
+    nodePort: {{ .Values.nginx.service.nodePort.port }}
+  {{- end }}
 {{ end }}
   selector:
     app: slackernews-nginx
-  type: {{ .Values.service.type }}
+  type: {{ .Values.nginx.service.type }}
 {{ end }}

--- a/chart/slackernews/templates/slackernews-deployment.yaml
+++ b/chart/slackernews/templates/slackernews-deployment.yaml
@@ -2,6 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: slackernews-frontend
+  annotations:
+    # if you're using a chart-managed secret, this will roll the deployment when the secret changes
+    checksum/slackernews-slack: {{ include (print $.Template.BasePath "/slack-secret.yaml") . | sha256sum }}
 spec:
   selector:
     matchLabels:
@@ -55,6 +58,8 @@ spec:
             value: "1"
           - name: INSTALL_METHOD
             value: helm
+          - name: SLACKERNEWS_ADMIN_USER_EMAILS
+            value: {{ .Values.slackernews.adminUserEmails | quote }}
           - name: KUBERNETES_NAMESPACE
             valueFrom:
               fieldRef:

--- a/chart/slackernews/values.yaml
+++ b/chart/slackernews/values.yaml
@@ -20,6 +20,11 @@ ingress:
   ingressClassName: ""
 nginx:
   enabled: false
+  service:
+    type: ClusterIP
+    nodePort:
+      port:
+
 service:
   type: ClusterIP
   nodePort:
@@ -45,9 +50,8 @@ slack:
 
 slackernews:
   domain: ""
+  adminUserEmails: ""
 
-admin-console:
-  enabled: true
 images:
   pullSecrets:
     replicated:
@@ -55,4 +59,3 @@ images:
   slackernews:
     repository: $REGISTRY/$IMAGE
     pullPolicy: IfNotPresent
-    pullSecret: proxypullsecret

--- a/kots/config.yaml
+++ b/kots/config.yaml
@@ -5,6 +5,10 @@ metadata:
 spec:
   groups:
     - name: postgres
+      description: >
+        This section can be used to configure the postgresql database required by SlackerNews. You
+        can either deploy postgresql in the cluster or provide an external URI to an existing postgresql instance
+        that you will use for SlackerNews.
       title: Postgresql
       items:
         - name: deploy_postgres
@@ -23,13 +27,77 @@ spec:
           title: Postgresql URI
           required: true
           when: repl{{ ConfigOptionEquals "deploy_postgres" "0"}}
-    - name: tls
-      title: TLS
+    - name: tls_and_ingress
+      title: TLS and Ingress
+      description: |
+        You can customize how you will expose SlackerNews to the internet.
+        Note that the domain you use will need to be publicly addressable with certs signed by a public authority 
+        so it can receive webhooks from Slack.
+        
+        Common configurations include:
+        
+        - **ClusterIP** Using a Cluster IP and configuring your existing ingress controller to route traffic to SlackerNews
+        - **NodePort** Using a NodePort and configuring an existing load balancer to route traffic to SlackerNews
+        - **LoadBalancer** Using a LoadBalancer service and letting Kubernetes provision a load balancer for you
+        - **Nginx** Deploying the included nginx service to handle TLS and proxying traffic to SlackerNews, and exposing that with a ClusterIP, NodePort, or LoadBalancer
+        
+        If you choose to use nginx, you'll see that this page has been pre-populated with self-signed certificates. 
+        If you want, you can replace the self-signed certificates with your own.
+        
+        If you'll be using your own ingress controller or external load balancer, use the DNS name of that external address.
+        
       items:
         - name: slackernews_domain
           title: Ingress Hostname
+          help_text: The domain name at which you'll access SlackerNews. Don't include the `https://` or any path elements.
           type: text
           required: true
+        - name: slackernews_service_type
+          title: Slackernews Service Type
+          type: select_one
+          items:
+            - name: ClusterIP
+              title: ClusterIP
+            - name: NodePort
+              title: NodePort
+            - name: LoadBalancer
+              title: LoadBalancer
+          default: ClusterIP
+        - name: slackernews_node_port_port
+          title: Slackernews Node Port
+          help_text: > 
+              (Optional) - The port to use for the NodePort service type. Leave this blank to have Kubernetes choose a port for you.
+          type: text
+          default: ""
+          when: repl{{ ConfigOptionEquals "slackernews_service_type" "NodePort" }}
+        - name: nginx_enabled
+          title: Enable Nginx
+          help_text: Deploy an nginx reverse proxy. Running nginx is required to customize the TLS configuration.
+          type: bool
+          default: "1"
+        - name: nginx_service_type
+          title: Nginx Service Type
+          help_text: > 
+              The service type to use for the nginx service. 
+              If you're using an external http or tcp load balancer, you should use NodePort. 
+              If you're running in a supported cloud provider and want Kubernetes to provision a Load Balancer, use LoadBalancer.
+          type: select_one
+          items:
+            - name: ClusterIP
+              title: ClusterIP
+            - name: NodePort
+              title: NodePort
+            - name: LoadBalancer
+              title: LoadBalancer
+          default: ClusterIP
+          when: repl{{ ConfigOptionEquals "nginx_enabled" "1" }}
+        - name: nginx_node_port_port
+          title: Nginx Node Port
+          help_text: > 
+              (Optional) - The port to use for the NodePort service type. Leave this blank to have Kubernetes choose a port for you.
+          type: text
+          default: ""
+          when: repl{{ and (ConfigOptionEquals "nginx_enabled" "1") (ConfigOptionEquals "nginx_service_type" "NodePort") }}
         - name: tls_json
           title: TLS JSON
           type: textarea
@@ -44,11 +112,50 @@ spec:
           title: Signing Authority
           type: textarea
           value: repl{{ fromJson (ConfigOption "tls_json") | dig "ca" "Cert" "" }}
+          when: repl{{ ConfigOptionEquals "nginx_enabled" "1" }}
         - name: tls_cert
           title: TLS Cert
           type: textarea
           value: repl{{ fromJson (ConfigOption "tls_json") | dig "cert" "Cert" "" }}
+          when: repl{{ ConfigOptionEquals "nginx_enabled" "1" }}
         - name: tls_key
           title: TLS Key
           type: textarea
           value: repl{{ fromJson (ConfigOption "tls_json") | dig "cert" "Key" "" }}
+          when: repl{{ ConfigOptionEquals "nginx_enabled" "1" }}
+    - name: slack
+      title: Slack Settings
+      description: |
+        If desired, you can preconfigure the slack settings for SlackerNews. 
+        These are required for logging into SlackerNews and pulling/organizing content from your slack instance.
+        If you don't preconfigure these settings, you'll be prompted to configure them when you first access SlackerNews.
+        
+        Instructions on how to configure your slack application and collect these values can be found in [the SlackerNewa slack documentation](https://docs.slackernews.io/slack/).
+      items:
+        - name: slack_user_token
+          title: User OAuth Token
+          type: password
+        - name: slack_bot_token
+          title: Bot User OAuth Token
+          type: password
+        - name: slack_clientid
+          title: Slack Client ID
+          type: text
+        - name: slack_clientsecret
+          title: Slack Client Secret
+          type: password
+    - name: admin_users
+      title: Admin Users
+      description: |
+        For this section, you can specify a list of users that will be granted admin access to SlackerNews.
+        Provide a comma-separated list of email addresses for the users you want to grant admin access to.
+        Since SlackerNews users Slack for authentication, these email addresses must match the users' email addresses in Slack.
+
+        Users on this list will be able to access the `/admin` route, allowing them to manage content, users, and settings.
+        
+        For any users who receive admin permissions from this setting, the change will take effect the next time
+        they are active in the slackernews application.
+      items:
+        - name: slackernews_admin_user_emails
+          title: Admin Users
+          type: text

--- a/kots/preflight.yaml
+++ b/kots/preflight.yaml
@@ -34,11 +34,14 @@ spec:
           - pass:
               when: "== eks"
               message: EKS is a supported platform
+          - pass:
+              when: "== k3s"
+              message: K3s is a supported platform
           - warn:
               when: "== docker-desktop"
               message: This application has not been tested on Docker Desktop
           - warn:
-              message: The Kubernetes platform is not validated, but there are no known compatibility issues.
+              message: This Kubernetes platform is not regularly tested, but there are no known compatibility issues.
     - textAnalyze:
         checkName: slack
         fileName: slack.json

--- a/kots/replicated-app.yaml
+++ b/kots/replicated-app.yaml
@@ -14,20 +14,13 @@ spec:
       localPort: 80
       applicationUrl: "http://slackernews-nginx"
   statusInformers:
-    - deployment/migrations
-    - deployment/slackernews-api
     - deployment/slackernews-frontend
-    - deployment/slackernews-nginx
+    - '{{repl if ConfigOptionEquals "deploy_postgres" "1"}}statefulset/postgres{{repl end}}'
+    - '{{repl if ConfigOptionEquals "nginx_enabled" "1"}}deployment/slackernews-nginx{{repl end}}'
   graphs:
     - title: DAU
       query: 'sum(user_signup_events_total)'
 images:
-  slackernews_api:
-    pullSecret: repl{{ ImagePullSecretName }}
-    repository: ghcr.io/slackernews/slackernews-api
-  slackernews_migrations:
-    pullSecret: repl{{ ImagePullSecretName }}
-    repository: ghcr.io/slackernews/slackernews-migrations
   slackernews:
     pullSecret: repl{{ ImagePullSecretName }}
     repository: ghcr.io/slackernews/slackernews-web

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -12,20 +12,33 @@ spec:
   # these values will be supplied to helm template
   values:
     postgres:
+      enabled: true
+      deploy_postgres: repl{{ ConfigOption "deploy_postgres" | ParseBool }}
       password: repl{{ ConfigOption "postgres_password"}}
+      uri: repl{{ ConfigOption "postgres_external_uri" }}
     slack:
-      botToken: repl{{ ConfigOption "slack_bot_token" }}
-      userToken: repl{{ ConfigOption "slack_user_token" }}
-      clientId: repl{{ ConfigOption "slack_clientid" }}
-      clientSecret: repl{{ ConfigOption "slack_clientsecret" }}
+      botToken: repl{{ ConfigOption "slack_bot_token" | quote }}
+      userToken: repl{{ ConfigOption "slack_user_token" | quote }}
+      clientId: repl{{ ConfigOption "slack_clientid" | quote }}
+      clientSecret: repl{{ ConfigOption "slack_clientsecret" | quote }}
     slackernews:
       domain: repl{{ ConfigOption "slackernews_domain" }}
+      adminUserEmails: repl{{ ConfigOption "slackernews_admin_user_emails" | quote }}
     admin-console:
       enabled: false
     replicated:
       enabled: false
       preflights: false
+    nginx:
+      enabled: repl{{ ConfigOption "nginx_enabled" | ParseBool }}
+      service:
+        type: repl{{ ConfigOption "nginx_service_type" }}
+        nodePort:
+          port: repl{{ ConfigOption "nginx_node_port_port" }}
     service:
+      type: repl{{ ConfigOption "slackernews_service_type" }}
+      nodePort:
+        port: repl{{ ConfigOption "slackernews_node_port_port" }}
       tls:
         enabled: true
         cert: |
@@ -36,15 +49,9 @@ spec:
       pullSecrets:
         replicated:
           dockerconfigjson: ""
-      slackernews_api:
-        pullSecret: repl{{ ImagePullSecretName }}
-        repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "images.slackernews.io" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace "proxy/slackernews/ghcr.io/slackernews" }}/slackernews-api'
-      slackernews_migrations:
-        pullSecret: repl{{ ImagePullSecretName }}
-        repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "images.slackernews.io" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace "proxy/slackernews/ghcr.io/slackernews" }}/slackernews-migrations'
       slackernews:
         pullSecret: repl{{ ImagePullSecretName }}
-        repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "images.slackernews.io" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace "proxy/slackernews/ghcr.io/slackernews" }}/slackernews-web'
+        repository: repl{{ LocalImageName "$IMAGE" }}
   # builder values provide a way to render the chart with all images
   # and manifests. this is used in replicated to create airgap packages
   builder:

--- a/slackernews/lib/share.ts
+++ b/slackernews/lib/share.ts
@@ -1,6 +1,4 @@
 import {getSequelize } from "./db";
-import parse from 'parse-duration'
-import { getParam } from "./param";
 import { SlackChannel, SlackUser } from "./slack";
 import { Link } from "./link";
 const { Sequelize, DataTypes } = require('sequelize');

--- a/slackernews/pages/admin/admin-console.js
+++ b/slackernews/pages/admin/admin-console.js
@@ -1,6 +1,5 @@
 import AdminLayout from "../../components/admin-layout";
-import React, { useEffect, useState } from 'react';
-import router, { useRouter } from 'next/router';
+import React from 'react';
 import { loadSession } from "../../lib/session";
 import cookies from 'next-cookies';
 
@@ -54,6 +53,7 @@ export async function getServerSideProps(ctx) {
       props:{},
     };
   }
+
 
   if (!sess.user.isSuperAdmin) {
     return {

--- a/slackernews/pages/debug/[url].js
+++ b/slackernews/pages/debug/[url].js
@@ -1,9 +1,10 @@
 import Layout from "../../components/layout";
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import "../../styles/Home.module.css";
 import { loadSession } from "../../lib/session";
 import cookies from 'next-cookies';
-import { getLink, listShares } from "../../lib/share";
+import { listShares } from "../../lib/share";
+import { getLink } from "../../lib/link";
 import Link from "next/link";
 import Button from 'react-bootstrap/Button';
 


### PR DESCRIPTION
Making the GHA build configurable
-------------------

Some changes to allow for building dev versions of slackernews off of a forked repo with a different vendor.replicated.com account.

- Update logic during GHA build to 

```diff
.github/workflows/tag.yaml

                 type=ref,event=branch
                 type=ref,event=tag
                 type=ref,event=pr
-          images: ${{ env.REGISTRY }}/slackernews/slackernews-web
+          images: ${{ env.REGISTRY }}/${{ secrets.GHCR_NAMESPACE }}/slackernews-web
```

- Make registry CNAME (`images.slackernews.io`) optional. 
  I've set `REPLICATED_PROXY_REGISTRY_CNAME` to `images.slackernews.io` in the upstream repo.

```diff
.github/workflows/tag.yaml

         with:
           include: 'chart/slackernews/values.yaml'
           find: '$REGISTRY'
-          replace: 'images.slackernews.io'
+          replace: ${{ secrets.REPLICATED_PROXY_REGISTRY_CNAME || 'proxy.replicated.com' }}
```

- Update the `$IMAGE` replacement logic to allow for templating the `REPLICATED_APP` as well as the `GHCR_NAMESPACE`. 
  The upstream repo values have been set to `slackernews` and slackernews`.

```diff
.github/workflows/tag.yaml

       - name: Update the values.yaml with the image path
         uses: jacobtomlinson/gha-find-replace@v2
         with:
           include: 'chart/slackernews/values.yaml'
           find: '$IMAGE'
-          replace: 'proxy/slackernews/ghcr.io/slackernews/slackernews-web:${{ steps.get_version.outputs.version-without-v }}'
+          replace: 'proxy/${{ secrets.REPLICATED_APP }}/ghcr.io/${{ secrets.GHCR_NAMESPACE }}/slackernews-web:${{ steps.get_version.outputs.version-without-v }}'
           regex: false
```


- Update the "Create unstable release" action invocation to use the REPLICATED_APP secret.

```diff
       - name: Create the unstable release
         uses: replicatedhq/action-kots-release@configurable-endpoint
         with:
-          replicated-app: "slackernews"
+          replicated-app: ${{ secrets.REPLICATED_APP }}
```

Image registry simplifications
-------------------

There were a lot of `HasLocalRegistry | ternary` functions in the `kots/slackernews-chart.yaml` file. I've simplified them to just use the `LocalImageName` function.

```diff
        repository: repl{{ LocalImageName "$IMAGE" }}
```

I tested this in a variety of scenarios:

#### Testing LocalImageName automatically populates proxy.replicated.com

I tried both of the following to confirm they result in the same final value being passed to the slackernews Helm Chart:

```yaml
repository: repl{{ LocalImageName "proxy.replicated.com/proxy/slackernews-dexter-s-version/ghcr.io/dexhorthy/slackernews-web:TAG" }}
```

and

```yaml
repository: repl{{ LocalImageName "ghcr.io/dexhorthy/slackernews-web:TAG" }}
```

I confirmed both result in the same value passed to the chart, so I went with the latter as it requires less templating logic.

<img width="1058" alt="proxy-in-release" src="https://github.com/slackernews/slackernews/assets/3730605/c3daade5-0fb2-4515-94da-a791500a88b2">

<img width="939" alt="just-ghcr-in-release" src="https://github.com/slackernews/slackernews/assets/3730605/515f1c13-cfb3-4425-a3f6-4a01a1b1c0e9">


From there, the only logic needed is to wire in the image name to the KOTS HelmChart Custom Resource during the GHA build:

```diff
.github/workflows/tag.yaml
           
+      - name: Update the KOTS HelmChart CR with the image path
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          include: 'kots/slackernews-chart.yaml'
+          find: '$IMAGE'
+          replace: 'ghcr.io/${{ secrets.GHCR_NAMESPACE }}/slackernews-web:${{ steps.get_version.outputs.version-without-v }}'
+          regex: false
```

And we get to simplify to:

```diff
kots/slackernews-chart.yaml

-        repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "images.slackernews.io" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace "proxy/slackernews/ghcr.io/slackernews" }}/slackernews-web'
+        repository: repl{{ LocalImageName "$IMAGE" }}
```

The previous version was also missing a tag, and always deployed `latest`, which may or may not have been intentional. 


I also removed the `repository` templates for `api` and `migrations`:


```diff
kots/slackernews-chart.yaml


-      slackernews_api:
-        pullSecret: repl{{ ImagePullSecretName }}
-        repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "images.slackernews.io" }}/{{repl Has
LocalRegistry | ternary LocalRegistryNamespace "proxy/slackernews/ghcr.io/slackernews" }}/slackernews-api'
-      slackernews_migrations:
-        pullSecret: repl{{ ImagePullSecretName }}
-        repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "images.slackernews.io" }}/{{repl Has
LocalRegistry | ternary LocalRegistryNamespace "proxy/slackernews/ghcr.io/slackernews" }}/slackernews-migration
s'
```

#### Confirming LocalImageName replaces proxy.replicated.com with a default custom domain

I also tested `{{ LocalImageName "$IMAGE" }}` workflow in the case where a default proxy registry CNAME is set on the application. After configuring `slackernews.dexhorthy.com` as a custom domain for `proxy.replicated.com`, and setting it as my "default", I created a new release, here's the slackernews-chart.yaml HelmChart CR in the release that was produced by GHA for the above case (replacing `$IMAGE`).

<img width="759" alt="custom-domain-image-release" src="https://github.com/slackernews/slackernews/assets/3730605/267b3a3b-89e0-4ee2-9b15-a0403fd68813">


And here's that being rendered correctly into values that use my custom domain:

<img width="1048" alt="custom-domain-rendered-values" src="https://github.com/slackernews/slackernews/assets/3730605/f4f9d018-905d-4163-b6cc-c9081a2d779b">


Postgresql Wiring
-------------------

- adjust kots HelmChart CR to properly pass in deploy_postgres value so the chart uses it properly. Based on the existing config screen, I'm assuming we never want to allow `sqlite` as the deployment in KOTS, so I'm hardcoding `postgres.enabled` (which controls which db slackernes uses) to `true` in the HelmChart CR. We can adjust that going forward if we want to allow for a `sqlite` workflow in KOTS, but I don't see a compelling enough use case to maintain that extra complexity in the configuration workflow right now.

```diff
kots/slackernews-chart.yaml

   values:
     postgres:
+      enabled: true
+      deploy_postgres: repl{{ ConfigOption "deploy_postgres" | ParseBool }}
       password: repl{{ ConfigOption "postgres_password"}}
+      uri: repl{{ ConfigOption "postgres_external_uri" }}

```

- I have not yet tested the "external postgres URI configuration", neither before nor after making this change. 

Admin User Changes
-------------------

Trying to streamline initial setup, so I don't have to manually run queries to give myself admin permissions. This was a scrappy solution for a problem with a lot of possible approaches.

- Add parameter `SLACKERNEWS_ADMIN_USER_EMAILS` to automatically bootstrap a set of comma-separated email addresses
- Update user.ts to check if superadmin bit is overriden by env var, and automatically flip it when fetching a user

```diff
slackernews/lib/user.ts

+    // when fetching a user, update their superAdmin bit if it's in the hardcoded list of emails
+    const hardCodedSuperAdmins = (process.env.SLACKERNEWS_ADMIN_USER_EMAILS || "").split(",");
+    const isSuperAdmin = hardCodedSuperAdmins.indexOf(user.email_address) !== -1;
+    if (isSuperAdmin && !user.is_super_admin ) {
+      console.log(`flipping on super-admin permissions for user ${id} because their email was present in SLACKERNEWS_ADMIN_USER_EMAILS`)
+      await setUserAdmin(user.id, true);
+    }
+
```


- Wire through kots/config.yaml, kots/slackernews-chart.yaml, charts/slackernews/values.yaml, charts/slackernews/templates/slackernews-deployment.yaml


```diff
kots/config.yaml

+    - name: admin_users
+      title: Admin Users
+      description: |
+        For this section, you can specify a list of users that will be granted admin access to SlackerNews.
+        Provide a comma-separated list of email addresses for the users you want to grant admin access to.
+        Since SlackerNews users Slack for authentication, these email addresses must match the users' email addresses in Slack.
+
+        Users on this list will be able to access the `/admin` route, allowing them to manage content, users, and settings.
+
+        For any users who receive admin permissions from this setting, the change will take effect the next time
+        they are active in the slackernews application.
+      items:
+        - name: slackernews_admin_user_emails
+          title: Admin Users
+          type: text
```

```diff
kots/slackernews-chart.yaml

     slackernews:
       domain: repl{{ ConfigOption "slackernews_domain" }}
+      adminUserEmails: repl{{ ConfigOption "slackernews_admin_user_emails" | quote }}
```




```diff
charts/slackernews/values.yaml

 slackernews:
   domain: ""
+  adminUserEmails: ""
```


```diff
charts/slackernews/templates/slackernews-deloyment.yaml

+          - name: SLACKERNEWS_ADMIN_USER_EMAILS
+            value: {{ .Values.slackernews.adminUserEmails | quote }}
```

- Test locally with `npm run dev` and with a KOTS deployment in CMX EKS


Slack config values in HelmChart CR
---------------------


Added some config options to KOTS config to allow for configuring the slack app.

```diff
kots/config.yaml


+    - name: slack
+      title: Slack Settings
+      description: |
+        If desired, you can preconfigure the slack settings for SlackerNews.
+        These are required for logging into SlackerNews and pulling/organizing content from your slack instance.
+        If you don't preconfigure these settings, you'll be prompted to configure them when you first access SlackerNews.
+
+        Instructions on how to configure your slack application and collect these values can be found in [the SlackerNewa slack documentation](https://docs.slackernews.io/slack/).
+      items:
+        - name: slack_clientid
+          title: Slack Client ID
+          type: text
+        - name: slack_clientsecret
+          title: Slack Client Secret
+          type: password
+        - name: slack_user_token
+          title: User OAuth Token
+          type: password
+        - name: slack_bot_token
+          title: Bot User OAuth Token
+          type: password
```

#### resolving quoting issues

There were some quoting issues where the config screen value was handled correctly

![client-id-config](https://github.com/slackernews/slackernews/assets/3730605/3985aec9-8767-42a9-a7b5-92a737561f84)



But when being passed to the helm chart values, it got parsed as a number:

<img width="783" alt="client-id-rendered" src="https://github.com/slackernews/slackernews/assets/3730605/ac7a9483-afd2-4567-936a-fb25357c0d62">



I added some quoting to the HelmChart CR to fix this:

```diff
kots/slackernews-chart.yaml

     slack:
-      botToken: repl{{ ConfigOption "slack_bot_token" }}
-      userToken: repl{{ ConfigOption "slack_user_token" }}
-      clientId: repl{{ ConfigOption "slack_clientid" }}
-      clientSecret: repl{{ ConfigOption "slack_clientsecret" }}
+      botToken: repl{{ ConfigOption "slack_bot_token" | quote }}
+      userToken: repl{{ ConfigOption "slack_user_token" | quote }}
+      clientId: repl{{ ConfigOption "slack_clientid" | quote }}
+      clientSecret: repl{{ ConfigOption "slack_clientsecret" | quote }}
```


Clean up Trivy Build
---------------------

Remove the api and migrations builds in trivy. As far as I can tell though, the web one still doesn't work.

NGINX updates
---------------------

- Update `service.type` value to only configure the slackernews `Service` - now the nginx `Service` honors `nginx.service.type` instead (similar for nodePort)



```diff
diff --git a/chart/slackernews/templates/nginx-service.yaml b/chart/slackernews/templates/nginx-service.yaml
index 3dd835f..6d5efcd 100644
--- a/chart/slackernews/templates/nginx-service.yaml
+++ b/chart/slackernews/templates/nginx-service.yaml
@@ -17,5 +17,5 @@ spec:
 {{ end }}
   selector:
     app: slackernews-nginx
-  type: {{ .Values.service.type }}
+  type: {{ .Values.nginx.service.type }}
```


```diff
charts/slackernews/values.yaml

 nginx:
   enabled: false
+  service:
+    type: ClusterIP
+    nodePort:
+      port:
+
 service:
   type: ClusterIP
   nodePort:
```


In general, expand config screen to allow for customizing service types, and to make nginx optional (and highlight that today, you need to deploy nginx if you want to customize the TLS config).


<img width="666" alt="Screenshot 2023-12-31 at 7 23 59 PM" src="https://github.com/slackernews/slackernews/assets/3730605/bb7a9c08-f118-4607-829a-b814cd9a693b">


```diff

-    - name: tls
-      title: TLS
+    - name: tls_and_ingress
+      title: TLS and Ingress
+      description: |
+        You can customize how you will expose SlackerNews to the internet.
+        Note that the domain you use will need to be publicly addressable with certs signed by a public authority
+        so it can receive webhooks from Slack.
+
+        Common configurations include
+
+        - Using a Cluster IP and configuring your existing ingress controller to route traffic to SlackerNews
+        - Using a NodePort and configuring an existing load balancer to route traffic to SlackerNews
+        - Using a LoadBalancer service and letting Kubernetes provision a load balancer for you
+        - Deploying the included nginx service to handle TLS and proxying traffic to SlackerNews, and exposing that with a ClusterIP, NodePort, or LoadBalancer
+
+        If you choose to use nginx, you'll see that this page has been pre-populated with self-signed certificates.
+        If you want, you can replace the self-signed certificates with your own.
+
+        If you'll be using your own ingress controller or external load balancer, use the DNS name of that external address.
+
       items:
         - name: slackernews_domain
           title: Ingress Hostname
+          help_text: The domain name at which you'll access SlackerNews. Don't include the `https://` or any path elements.
           type: text
           required: true
+        - name: slackernews_service_type
+          title: Slackernews Service Type
+          type: select_one
+          items:
+            - name: ClusterIP
+              title: ClusterIP
+            - name: NodePort
+              title: NodePort
+            - name: LoadBalancer
+              title: LoadBalancer
+          default: ClusterIP
+        - name: slackernews_node_port_port
+          title: Slackernews Node Port
+          help_text: >
+              (Optional) - The port to use for the NodePort service type. Leave this blank to have Kubernetes choose a port for you.
+          type: text
+          default: ""
+          when: repl{{ ConfigOptionEquals "slackernews_service_type" "NodePort" }}
+        - name: nginx_enabled
+          title: Enable Nginx
+          help_text: Deploy an nginx reverse proxy. Running nginx is required to customize the TLS configuration.
+          type: bool
+          default: "1"
+        - name: nginx_service_type
+          title: Nginx Service Type
+          help_text: >
+              The service type to use for the nginx service.
+              If you're using an external http or tcp load balancer, you should use NodePort.
+              If you're running in a supported cloud provider and want Kubernetes to provision a Load Balancer, use LoadBalancer.
+          type: select_one
+          items:
+            - name: ClusterIP
+              title: ClusterIP
+            - name: NodePort
+              title: NodePort
+            - name: LoadBalancer
+              title: LoadBalancer
+          default: ClusterIP
+          when: repl{{ ConfigOptionEquals "nginx_enabled" "1" }}
+        - name: nginx_node_port_port
+          title: Nginx Node Port
+          help_text: >
+              (Optional) - The port to use for the NodePort service type. Leave this blank to have Kubernetes choose a port for you.
+          type: text
+          default: ""
+          when: repl{{ and (ConfigOptionEquals "nginx_enabled" "1") (ConfigOptionEquals "nginx_service_type" "NodePort") }}
         - name: tls_json
           title: TLS JSON
           type: textarea
@@ -44,11 +112,50 @@ spec:
           title: Signing Authority
           type: textarea
           value: repl{{ fromJson (ConfigOption "tls_json") | dig "ca" "Cert" "" }}
+          when: repl{{ ConfigOptionEquals "nginx_enabled" "1" }}
         - name: tls_cert
           title: TLS Cert
           type: textarea
           value: repl{{ fromJson (ConfigOption "tls_json") | dig "cert" "Cert" "" }}
+          when: repl{{ ConfigOptionEquals "nginx_enabled" "1" }}
         - name: tls_key
           title: TLS Key
           type: textarea
           value: repl{{ fromJson (ConfigOption "tls_json") | dig "cert" "Key" "" }}
+          when: repl{{ ConfigOptionEquals "nginx_enabled" "1" }}
```


Related wiring into HelmChart CR:

```diff
kots/slackernews-chart.yaml

+    nginx:
+      enabled: repl{{ ConfigOption "nginx_enabled" | ParseBool }}
+      service:
+        type: repl{{ ConfigOption "nginx_service_type" }}
+        nodePort:
+          port: repl{{ ConfigOption "nginx_node_port_port" }}
     service:
+      type: repl{{ ConfigOption "slackernews_service_type" }}
+      nodePort:
+        port: repl{{ ConfigOption "slackernews_node_port_port" }}
       tls:
         enabled: true
         cert: |
```

Add K3s as a supported distro in Preflight Checks
-----------------

We test it in CMX, so it should probably be supported

```diff
charts/slackernews/templates/preflight.yaml

           - pass:
               when: "== eks"
               message: EKS is a supported platform
+          - pass:
+              when: "== k3s"
+              message: K3s is a supported platform
           - warn:
               when: "== docker-desktop"
               message: This application has not been tested on Docker Desktop
           - warn:
-              message: The Kubernetes platform is not validated, but there are no known compatibility issues.
+              message: This Kubernetes platform is not regularly tested, but there are no known compatibility issues.

```

Fix KOTS StatusInformers
--------------------

Remove api and migrations, add conditional informers for postgres and nginx. Also remove api and migrations from `images`. 

```diff
--- a/kots/replicated-app.yaml
+++ b/kots/replicated-app.yaml
@@ -14,20 +14,13 @@ spec:
       localPort: 80
       applicationUrl: "http://slackernews-nginx"
   statusInformers:
-    - deployment/migrations
-    - deployment/slackernews-api
     - deployment/slackernews-frontend
-    - deployment/slackernews-nginx
+    - '{{repl if ConfigOptionEquals "deploy_postgres" "1"}}statefulset/postgres{{repl end}}'
+    - '{{repl if ConfigOptionEquals "nginx_enabled" "1"}}deployment/nginx{{repl end}}'
   graphs:
     - title: DAU
       query: 'sum(user_signup_events_total)'
 images:
-  slackernews_api:
-    pullSecret: repl{{ ImagePullSecretName }}
-    repository: ghcr.io/slackernews/slackernews-api
-  slackernews_migrations:
-    pullSecret: repl{{ ImagePullSecretName }}
-    repository: ghcr.io/slackernews/slackernews-migrations
```


Fix a broken import, remove some unused imports
-------------


```diff
@@ -1,9 +1,10 @@
 import Layout from "../../components/layout";
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import "../../styles/Home.module.css";
 import { loadSession } from "../../lib/session";
 import cookies from 'next-cookies';
-import { getLink, listShares } from "../../lib/share";
+import { listShares } from "../../lib/share";
+import { getLink } from "../../lib/link";
 import Link from "next/link";
 import Button from 'react-bootstrap/Button';

```


```diff
@@ -1,6 +1,5 @@
 import AdminLayout from "../../components/admin-layout";
-import React, { useEffect, useState } from 'react';
-import router, { useRouter } from 'next/router';
+import React from 'react';
 import { loadSession } from "../../lib/session";
 import cookies from 'next-cookies';
```