### PR TITLE
Adds a very simple embedded cluster controller to specify the version

### DIFF
--- a/kots/embeddedcluster.yaml
+++ b/kots/embeddedcluster.yaml
@@ -1,0 +1,4 @@
+apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+spec:
+  version: 1.28.4+ec.5

--- a/kots/embeddedcluster.yaml
+++ b/kots/embeddedcluster.yaml
@@ -1,4 +1,4 @@
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 1.28.5+ec.2
+  version: 1.28.5+ec.3

--- a/kots/embeddedcluster.yaml
+++ b/kots/embeddedcluster.yaml
@@ -1,4 +1,4 @@
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 1.28.4+ec.5
+  version: 1.28.5+ec.2

--- a/kots/embeddedcluster.yaml
+++ b/kots/embeddedcluster.yaml
@@ -1,4 +1,4 @@
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 1.29.1+ec.0
+  version: 1.29.1+ec.4

--- a/kots/embeddedcluster.yaml
+++ b/kots/embeddedcluster.yaml
@@ -1,4 +1,4 @@
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 1.29.1+ec.4
+  version: 1.29.2+ec.9

--- a/kots/embeddedcluster.yaml
+++ b/kots/embeddedcluster.yaml
@@ -1,4 +1,4 @@
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 1.28.5+ec.3
+  version: 1.29.1+ec.0


### PR DESCRIPTION
TL;DR
-----

Specifies a bare minimal embedded cluster config with current version

Details
-------

Updates the KOTS configuration with a simple embedded cluster configuration to
give us a starting point for the future. It's also convenient for me since I'm
trying to stop working from a fork for all my demos and I use the embedded 
cluster regularly as the baseline for all KOTS demos
