### PR TITLE
Reworks the KOTS config to be more opinionated

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -115,7 +115,6 @@ jobs:
             --version=${{ steps.get_version.outputs.version-without-v }} \
             ./slackernews
 
-
       - name: Copy the helm chart to the kots directory
         run: cp ./chart/slackernews-${{ steps.get_version.outputs.version-without-v }}.tgz ./kots
 
@@ -142,7 +141,6 @@ jobs:
           find: '$NAMESPACE'
           replace: '${{ secrets.GHCR_NAMESPACE }}'
           regex: false
-
 
       - name: Create the unstable release
         uses: replicatedhq/action-kots-release@configurable-endpoint

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -105,14 +105,6 @@ jobs:
           replace: 'proxy/${{ secrets.REPLICATED_APP }}/ghcr.io/${{ secrets.GHCR_NAMESPACE }}/slackernews-nginx:${{ steps.get_version.outputs.version-without-v }}'
           regex: false
 
-      - name: Update the KOTS HelmChart CR with the image path
-        uses: jacobtomlinson/gha-find-replace@v2
-        with:
-          include: 'kots/slackernews-chart.yaml'
-          find: '$IMAGE'
-          replace: 'ghcr.io/${{ secrets.GHCR_NAMESPACE }}/slackernews-web:${{ steps.get_version.outputs.version-without-v }}'
-          regex: false
-
       - id: package-helm-chart
         run: |
           cd chart/slackernews && \
@@ -127,13 +119,30 @@ jobs:
       - name: Copy the helm chart to the kots directory
         run: cp ./chart/slackernews-${{ steps.get_version.outputs.version-without-v }}.tgz ./kots
 
-      - name: Update the HelmChart kind
+      - name: Update the version in the KOTS HelmChart kind
         uses: jacobtomlinson/gha-find-replace@v2
         with:
           include: 'kots/slackernews-chart.yaml'
           find: '$VERSION'
           replace: '${{ steps.get_version.outputs.version-without-v }}'
           regex: false
+
+      - name: Update the KOTS HelmChart kind with the registry name
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          include: 'kots/slackernews-chart.yaml'
+          find: '$REGISTRY'
+          replace: '${{ secrets.REPLICATED_PROXY_REGISTRY_CNAME }}'
+          regex: false
+
+      - name: Update the KOTS HelmChart kind with the image namespace
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          include: 'kots/slackernews-chart.yaml'
+          find: '$NAMESPACE'
+          replace: '${{ secrets.GHCR_NAMESPACE }}'
+          regex: false
+
 
       - name: Create the unstable release
         uses: replicatedhq/action-kots-release@configurable-endpoint

--- a/kots/config.yaml
+++ b/kots/config.yaml
@@ -71,11 +71,6 @@ spec:
           type: text
           default: ""
           when: repl{{ ConfigOptionEquals "slackernews_service_type" "NodePort" }}
-        - name: nginx_service_type
-          title: Nginx Service Type
-          help_text: >
-              The service type to use for the nginx service.
-              If you're using an external http or tcp load balancer, you should use NodePort.
         - name: service_type
           title: Service Type
               If you're running in a supported cloud provider and want Kubernetes to provision a Load Balancer, use LoadBalancer.

--- a/kots/config.yaml
+++ b/kots/config.yaml
@@ -47,33 +47,10 @@ spec:
         - **NodePort** Using a NodePort and configuring an existing load balancer to route traffic to SlackerNews
         - **LoadBalancer** Using a LoadBalancer service and letting Kubernetes provision a load balancer for you
 
+        If you're running in a supported cloud provider and want Kubernetes to provision a Load Balancer, use LoadBalancer.
       items:
-        - name: slackernews_domain
-          title: Ingress Hostname
-          help_text: The domain name at which you'll access SlackerNews. Don't include the `https://` or any path elements.
-          type: text
-          required: true
-        - name: slackernews_service_type
-          title: Slackernews Service Type
-          type: select_one
-          items:
-            - name: ClusterIP
-              title: ClusterIP
-            - name: NodePort
-              title: NodePort
-            - name: LoadBalancer
-              title: LoadBalancer
-          default: ClusterIP
-        - name: slackernews_node_port_port
-          title: Slackernews Node Port
-          help_text: >
-              (Optional) - The port to use for the NodePort service type. Leave this blank to have Kubernetes choose a port for you.
-          type: text
-          default: ""
-          when: repl{{ ConfigOptionEquals "slackernews_service_type" "NodePort" }}
         - name: service_type
           title: Service Type
-              If you're running in a supported cloud provider and want Kubernetes to provision a Load Balancer, use LoadBalancer.
           type: select_one
           items:
             - name: cluster_ip

--- a/kots/config.yaml
+++ b/kots/config.yaml
@@ -93,13 +93,13 @@ spec:
               If you're running in a supported cloud provider and want Kubernetes to provision a Load Balancer, use LoadBalancer.
           type: select_one
           items:
-            - name: ClusterIP
+            - name: cluster_ip
               title: ClusterIP
-            - name: NodePort
+            - name: node_port
               title: NodePort
-            - name: LoadBalancer
+            - name: load_balancer
               title: LoadBalancer
-          default: ClusterIP
+          default: cluster_ip
         - name: node_port_port
           title: Node Port
           help_text: > 

--- a/kots/config.yaml
+++ b/kots/config.yaml
@@ -4,31 +4,34 @@ metadata:
   name: slackernews-config
 spec:
   groups:
-    - name: postgres
-      description: >
-        This section can be used to configure the postgresql database required by SlackerNews. You
-        can either deploy postgresql in the cluster or provide an external URI to an existing postgresql instance
-        that you will use for SlackerNews.
-      title: Postgresql
+    - name: slackernews
+      title: Application Core
+      description: |
+        For this section, you can specify some core parameters for how
+        Slackernews operates, including the domain where users will access it
+        and the user who can administer it.
+
+        Users that you specify under **Admin Users** will be able to access the
+        Slackernews adminstrative console at `/admin`, allowing them to manage
+        content, users, and settings. Changes will take effect the next time
+        they are active in the Slackernews application.
       items:
-        - name: deploy_postgres
-          type: bool
-          title: Deploy Postgresql In Cluster
-          default: "1"
-        - name: postgres_password
-          type: password
-          title: Postgresql Password
-          required: true
-          hidden: true
-          when: repl{{ ConfigOptionEquals "deploy_postgres" "1"}}
-          value: repl{{ RandomString 40}}
-        - name: postgres_external_uri
+        - name: slackernews_domain
+          title: Ingress Hostname
+          help_text: >
+            The domain name at which you'll access SlackerNews. Don't include
+            the `https://` or any path elements.
           type: text
-          title: Postgresql URI
           required: true
-          when: repl{{ ConfigOptionEquals "deploy_postgres" "0"}}
-    - name: tls_and_ingress
-      title: TLS and Ingress
+        - name: slackernews_admin_user_emails
+          title: Admin Users
+          type: text
+          help_text: >
+            Provide a comma-separated list of email addresses for the users you
+            want to grant admin access to.
+
+    - name: ingress
+      title: Application Access
       description: |
         You can customize how you will expose SlackerNews to the internet.
         Note that the domain you use will need to be publicly addressable with certs signed by a public authority
@@ -39,14 +42,20 @@ spec:
         - **ClusterIP** Using a Cluster IP and configuring your existing ingress controller to route traffic to SlackerNews
         - **NodePort** Using a NodePort and configuring an existing load balancer to route traffic to SlackerNews
         - **LoadBalancer** Using a LoadBalancer service and letting Kubernetes provision a load balancer for you
+<<<<<<< HEAD
         - **Nginx** Deploying the included nginx service to handle TLS and proxying traffic to SlackerNews, and exposing that with a ClusterIP, NodePort, or LoadBalancer
 
         If you choose to use nginx, you'll see that this page has been pre-populated with self-signed certificates.
+=======
+        
+        If you choose to use nginx, you'll see that this page has been pre-populated with self-signed certificates. 
+>>>>>>> bfb361c (Reworks the KOTS config to be more opinionated)
         If you want, you can replace the self-signed certificates with your own.
 
         If you'll be using your own ingress controller or external load balancer, use the DNS name of that external address.
 
       items:
+<<<<<<< HEAD
         - name: slackernews_domain
           title: Ingress Hostname
           help_text: The domain name at which you'll access SlackerNews. Don't include the `https://` or any path elements.
@@ -75,6 +84,8 @@ spec:
           help_text: >
               The service type to use for the nginx service.
               If you're using an external http or tcp load balancer, you should use NodePort.
+        - name: service_type
+          title: Service Type
               If you're running in a supported cloud provider and want Kubernetes to provision a Load Balancer, use LoadBalancer.
           type: select_one
           items:
@@ -85,35 +96,42 @@ spec:
             - name: LoadBalancer
               title: LoadBalancer
           default: ClusterIP
-        - name: nginx_node_port_port
-          title: Nginx Node Port
-          help_text: >
+        - name: node_port_port
+          title: Node Port
+          help_text: > 
               (Optional) - The port to use for the NodePort service type. Leave this blank to have Kubernetes choose a port for you.
           type: text
           default: ""
-          when: repl{{ ConfigOptionEquals "nginx_service_type" "NodePort" }}
-        - name: tls_json
-          title: TLS JSON
-          type: textarea
-          hidden: true
-          value: |-
-            repl{{ $ca := genCA (ConfigOption "ingress_hostname") 365 }}
-            repl{{ $tls := dict "ca" $ca }}
-            repl{{ $cert := genSignedCert (ConfigOption "ingress_hostname") (list ) (list (ConfigOption "ingress_hostname")) 365 $ca }}
-            repl{{ $_ := set $tls "cert" $cert }}
-            repl{{ toJson $tls }}
+          when: repl{{ ConfigOptionEquals "service_type" "NodePort" }}
+
+    - name: tls
+      title: Certificates
+      description: |
+        You can secure the Slackernews application with certificates from a trusted certificate authority 
+        or we can generate them for you. We recommend that you upload your own certificates for production installations.
+      items:
+        - name: certificate_source
+          type: select_one
+          title: Certificate Source
+          default: generate_internal
+          items:
+            - name: generate_internal
+              title: Generate
+            - name: upload_existing
+              title: Upload
+        - name: tls_cert
+          title: Certificate
+          type: file
+          when: '{{repl ConfigOptionEquals "certificate_source" "upload_existing"}}'
+        - name: tls_key
+          title: Private Key
+          type: file
+          when: '{{repl ConfigOptionEquals "certificate_source" "upload_existing"}}'
         - name: tls_ca
           title: Signing Authority
-          type: textarea
-          value: repl{{ fromJson (ConfigOption "tls_json") | dig "ca" "Cert" "" }}
-        - name: tls_cert
-          title: TLS Cert
-          type: textarea
-          value: repl{{ fromJson (ConfigOption "tls_json") | dig "cert" "Cert" "" }}
-        - name: tls_key
-          title: TLS Key
-          type: textarea
-          value: repl{{ fromJson (ConfigOption "tls_json") | dig "cert" "Key" "" }}
+          type: file
+          when: '{{repl ConfigOptionEquals "certificate_source" "upload_existing"}}'
+
     - name: slack
       title: Slack Settings
       description: |
@@ -121,7 +139,7 @@ spec:
         These are required for logging into SlackerNews and pulling/organizing content from your slack instance.
         If you don't preconfigure these settings, you'll be prompted to configure them when you first access SlackerNews.
 
-        Instructions on how to configure your slack application and collect these values can be found in [the SlackerNewa slack documentation](https://docs.slackernews.io/slack/).
+        Instructions on how to configure your slack application and collect these values can be found in [the SlackerNews slack documentation](https://docs.slackernews.io/slack/).
       items:
         - name: slack_user_token
           title: User OAuth Token
@@ -135,18 +153,27 @@ spec:
         - name: slack_clientsecret
           title: Slack Client Secret
           type: password
-    - name: admin_users
-      title: Admin Users
-      description: |
-        For this section, you can specify a list of users that will be granted admin access to SlackerNews.
-        Provide a comma-separated list of email addresses for the users you want to grant admin access to.
-        Since SlackerNews users Slack for authentication, these email addresses must match the users' email addresses in Slack.
 
-        Users on this list will be able to access the `/admin` route, allowing them to manage content, users, and settings.
-
-        For any users who receive admin permissions from this setting, the change will take effect the next time
-        they are active in the slackernews application.
+    - name: postgres
+      description: >
+        This section can be used to configure the postgresql database required by SlackerNews. You
+        can either deploy postgresql as part of the installation or provide an external URI to an existing postgresql instance
+        that you will use for SlackerNews.
+      title: Postgresql
       items:
-        - name: slackernews_admin_user_emails
-          title: Admin Users
+        - name: deploy_postgres
+          type: bool
+          title: Deploy Postgresql Database
+          default: "1"
+        - name: postgres_password
+          type: password
+          title: Postgresql Password
+          required: true
+          hidden: true
+          when: repl{{ ConfigOptionEquals "deploy_postgres" "1"}}
+          value: repl{{ RandomString 40}}
+        - name: postgres_external_uri
           type: text
+          title: Postgresql URI
+          required: true
+          when: repl{{ ConfigOptionEquals "deploy_postgres" "0"}}

--- a/kots/config.yaml
+++ b/kots/config.yaml
@@ -46,20 +46,8 @@ spec:
         - **ClusterIP** Using a Cluster IP and configuring your existing ingress controller to route traffic to SlackerNews
         - **NodePort** Using a NodePort and configuring an existing load balancer to route traffic to SlackerNews
         - **LoadBalancer** Using a LoadBalancer service and letting Kubernetes provision a load balancer for you
-<<<<<<< HEAD
-        - **Nginx** Deploying the included nginx service to handle TLS and proxying traffic to SlackerNews, and exposing that with a ClusterIP, NodePort, or LoadBalancer
-
-        If you choose to use nginx, you'll see that this page has been pre-populated with self-signed certificates.
-=======
-        
-        If you choose to use nginx, you'll see that this page has been pre-populated with self-signed certificates. 
->>>>>>> bfb361c (Reworks the KOTS config to be more opinionated)
-        If you want, you can replace the self-signed certificates with your own.
-
-        If you'll be using your own ingress controller or external load balancer, use the DNS name of that external address.
 
       items:
-<<<<<<< HEAD
         - name: slackernews_domain
           title: Ingress Hostname
           help_text: The domain name at which you'll access SlackerNews. Don't include the `https://` or any path elements.

--- a/kots/config.yaml
+++ b/kots/config.yaml
@@ -105,6 +105,12 @@ spec:
 
         Instructions on how to configure your slack application and collect these values can be found in [the SlackerNews slack documentation](https://docs.slackernews.io/slack/).
       items:
+        - name: slack_clientid
+          title: Slack Client ID
+          type: text
+        - name: slack_clientsecret
+          title: Slack Client Secret
+          type: password
         - name: slack_user_token
           title: User OAuth Token
           type: password
@@ -119,12 +125,6 @@ spec:
             regex: 
               pattern: ^xoxb-.*$
               message: Please enter the Slack bot token for your instance of Slackernews
-        - name: slack_clientid
-          title: Slack Client ID
-          type: text
-        - name: slack_clientsecret
-          title: Slack Client Secret
-          type: password
 
     - name: postgres
       description: >

--- a/kots/config.yaml
+++ b/kots/config.yaml
@@ -23,6 +23,10 @@ spec:
             the `https://` or any path elements.
           type: text
           required: true
+          validation:
+            regex: 
+              pattern: ^(([a-zA-Z]{1})|([a-zA-Z]{1}[a-zA-Z]{1})|([a-zA-Z]{1}[0-9]{1})|([0-9]{1}[a-zA-Z]{1})|([a-zA-Z0-9][a-zA-Z0-9-_]{1,61}[a-zA-Z0-9]))\.([a-zA-Z]{2,6}|[a-zA-Z0-9-]{2,30}\.[a-zA-Z]{2,3})$
+              message: Please enter a valid hostname
         - name: slackernews_admin_user_emails
           title: Admin Users
           type: text
@@ -144,9 +148,17 @@ spec:
         - name: slack_user_token
           title: User OAuth Token
           type: password
+          validation:
+            regex: 
+              pattern: ^xoxp-.*$
+              message: Please enter the Slack user token for your instance of Slackernews
         - name: slack_bot_token
           title: Bot User OAuth Token
           type: password
+          validation:
+            regex: 
+              pattern: ^xoxb-.*$
+              message: Please enter the Slack bot token for your instance of Slackernews
         - name: slack_clientid
           title: Slack Client ID
           type: text

--- a/kots/replicated-app.yaml
+++ b/kots/replicated-app.yaml
@@ -14,9 +14,9 @@ spec:
       localPort: 3000
       applicationUrl: "http://slackernews"
   statusInformers:
-    - deployment/slackernews
-    - '{{repl if ConfigOptionEquals "deploy_postgres" "1"}}statefulset/postgres{{repl end}}'
+    - deployment/slackernews-frontend
     - deployment/slackernews-nginx
+    - '{{repl if ConfigOptionEquals "deploy_postgres" "1"}}statefulset/postgres{{repl end}}'
   graphs:
     - title: DAU
       query: 'sum(user_signup_events_total)'

--- a/kots/replicated-app.yaml
+++ b/kots/replicated-app.yaml
@@ -14,7 +14,7 @@ spec:
       localPort: 3000
       applicationUrl: "http://slackernews"
   statusInformers:
-    - deployment/slackernews-frontend
+    - deployment/slackernews
     - deployment/slackernews-nginx
     - '{{repl if ConfigOptionEquals "deploy_postgres" "1"}}statefulset/postgres{{repl end}}'
   graphs:

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -6,7 +6,7 @@ spec:
   # chart identifies a matching chart from a .tgz
   chart:
     name: slackernews
-    chartVersion: 1.0.10
+    chartVersion: $VERSION
 
   # values are used in the customer environment, as a pre-render step
   # these values will be supplied to helm template

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -42,14 +42,6 @@ spec:
         pullSecret: repl{{ ImagePullSecretName }}
         repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/ghcr.io/$NAMESPACE/slackernews" ) }}/slackernews-web:$VERSION'
  
-  # builder values provide a way to render the chart with all images
-  # and manifests. this is used in replicated to create airgap packages
-  builder:
-    postgres:
-      password: repl{{ ConfigOption "postgres_password"}}
-    admin-console:
-      enabled: false
-
   optionalValues:
     - when: '{{repl ConfigOptionEquals "deploy_postgres" "1"}}'
       recursiveMerge: true
@@ -104,3 +96,11 @@ spec:
             key: |-
               {{repl $cert.Key | nindent 14 }}
  
+  # builder values provide a way to render the chart with all images
+  # and manifests. this is used in replicated to create airgap packages
+  builder:
+    postgres:
+      password: repl{{ ConfigOption "postgres_password"}}
+    admin-console:
+      enabled: false
+

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -42,7 +42,8 @@ spec:
           dockerconfigjson: ""
       slackernews:
         pullSecret: repl{{ ImagePullSecretName }}
-        repository: repl{{ LocalImageName "$IMAGE" }}
+        repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/ghcr.io/$NAMESPACE/slackernews" ) }}/slackernews-web:$VERSION'
+ 
   # builder values provide a way to render the chart with all images
   # and manifests. this is used in replicated to create airgap packages
   builder:

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -34,8 +34,6 @@ spec:
       enabled: true 
       service:
         type: repl{{ ConfigOption "service_type" }}
-        nodePort:
-          port: repl{{ ConfigOption "node_port_port" }}
     images:
       pullSecrets:
         replicated:
@@ -69,7 +67,6 @@ spec:
       recursiveMerge: true
       values:
         nginx:
-          enabled: true
           service:
             type: LoadBalancer
 
@@ -77,11 +74,10 @@ spec:
       recursiveMerge: true
       values:
         nginx:
-          enabled: true
           service:
             type: NodePort
             nodePort:
-              port: '{{repl ConfigOption "node_port_port" }}'
+              port: repl{{ ConfigOption "node_port_port" }}
 
     - when: '{{repl ConfigOptionEquals "certificate_source" "upload_existing"}}'
       recursiveMerge: true

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -27,6 +27,9 @@ spec:
     replicated:
       enabled: false
       preflights: false
+    service:
+      tls:
+        enabled: true
     nginx:
       enabled: true 
       service:
@@ -60,6 +63,24 @@ spec:
       values:
         postgres:
           uri: '{{repl ConfigOption "postgres_external_uri" }}'
+
+    - when: '{{repl ConfigOptionEquals "service_type" "load_balancer"}}'
+      recursiveMerge: true
+      values:
+        nginx:
+          enabled: true
+          service:
+            type: LoadBalancer
+
+    - when: '{{repl ConfigOptionEquals "service_type" "node_port"}}'
+      recursiveMerge: true
+      values:
+        nginx:
+          enabled: true
+          service:
+            type: NodePort
+            nodePort:
+              port: '{{repl ConfigOption "node_port_port" }}'
 
     - when: '{{repl ConfigOptionEquals "certificate_source" "upload_existing"}}'
       recursiveMerge: true

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -14,8 +14,6 @@ spec:
     postgres:
       enabled: true
       deploy_postgres: repl{{ ConfigOption "deploy_postgres" | ParseBool }}
-      password: repl{{ ConfigOption "postgres_password"}}
-      uri: repl{{ ConfigOption "postgres_external_uri" }}
     slack:
       botToken: repl{{ ConfigOption "slack_bot_token" | quote }}
       userToken: repl{{ ConfigOption "slack_user_token" | quote }}
@@ -51,6 +49,18 @@ spec:
       enabled: false
 
   optionalValues:
+    - when: '{{repl ConfigOptionEquals "deploy_postgres" "1"}}'
+      recursiveMerge: true
+      values:
+        postgres:
+          password: '{{repl ConfigOption "postgres_password" }}'
+        
+    - when: '{{repl ConfigOptionEquals "deploy_postgres" "0"}}'
+      recursiveMerge: true
+      values:
+        postgres:
+          uri: '{{repl ConfigOption "postgres_external_uri" }}'
+
     - when: '{{repl ConfigOptionEquals "certificate_source" "upload_existing"}}'
       recursiveMerge: true
       values:

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -40,7 +40,7 @@ spec:
           dockerconfigjson: ""
       slackernews:
         pullSecret: repl{{ ImagePullSecretName }}
-        repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/ghcr.io/$NAMESPACE/slackernews" ) }}/slackernews-web:$VERSION'
+        repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/ghcr.io/$NAMESPACEs" ) }}/slackernews-web:$VERSION'
  
   optionalValues:
     - when: '{{repl ConfigOptionEquals "deploy_postgres" "1"}}'

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -40,7 +40,7 @@ spec:
           dockerconfigjson: ""
       slackernews:
         pullSecret: repl{{ ImagePullSecretName }}
-        repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/ghcr.io/$NAMESPACEs" ) }}/slackernews-web:$VERSION'
+        repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/ghcr.io/$NAMESPACE" ) }}/slackernews-web:$VERSION'
  
   optionalValues:
     - when: '{{repl ConfigOptionEquals "deploy_postgres" "1"}}'

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -6,7 +6,7 @@ spec:
   # chart identifies a matching chart from a .tgz
   chart:
     name: slackernews
-    chartVersion: $VERSION
+    chartVersion: 1.0.10
 
   # values are used in the customer environment, as a pre-render step
   # these values will be supplied to helm template
@@ -30,20 +30,11 @@ spec:
       enabled: false
       preflights: false
     nginx:
+      enabled: true 
       service:
-        type: repl{{ ConfigOption "nginx_service_type" }}
+        type: repl{{ ConfigOption "service_type" }}
         nodePort:
-          port: repl{{ ConfigOption "nginx_node_port_port" }}
-    service:
-      type: repl{{ ConfigOption "slackernews_service_type" }}
-      nodePort:
-        port: repl{{ ConfigOption "slackernews_node_port_port" }}
-      tls:
-        enabled: true
-        cert: |
-          repl{{ ConfigOption "tls_cert" | nindent 10 }}
-        key: |
-          repl{{ ConfigOption "tls_key" | nindent 10 }}
+          port: repl{{ ConfigOption "node_port_port" }}
     images:
       pullSecrets:
         replicated:
@@ -58,3 +49,30 @@ spec:
       password: repl{{ ConfigOption "postgres_password"}}
     admin-console:
       enabled: false
+
+  optionalValues:
+    - when: '{{repl ConfigOptionEquals "certificate_source" "upload_existing"}}'
+      recursiveMerge: true
+      values:
+        service:
+          tls:
+            enabled: true
+            cert: repl{{ ConfigOptionData "tls_cert" | nindent 14 }}
+            key: repl{{ ConfigOptionData "tls_key" | nindent 14 }}
+            ca: repl{{ ConfigOptionData "tls_ca" | nindent 14 }}
+        
+    - when: '{{repl ConfigOptionEquals "certificate_source" "generate_internal"}}'
+      recursiveMerge: true
+      values:
+        service:
+          tls:
+            enabled: true
+            ca: |-
+              {{repl $ca := genCA (LicenseFieldValue "customerName") 365 }}
+              {{repl $ca.Cert | Base64Encode}}
+            cert: |-
+              {{repl $cert := genSignedCert (ConfigOption "slackernews_domain") nil (list (ConfigOption "slackernews_domain")) 365 $ca }}
+              {{repl $cert.Cert | nindent 14 }}
+            key: |-
+              {{repl $cert.Key | nindent 14 }}
+ 


### PR DESCRIPTION
TL;DR
-----

Simplifies the KOTS admin screen by asserting more opinions

Details
-------

Makes the following updates to the KOTS config screen in hopes
of simplfiying it per #45 :

1. Avoids asking about NGINX. It's used for all deployments which
   allows for always specifying `ClusterIP` as the service type
   for the Slackernews service. This means only one prompt for
   the service type and one less option around NGINX.

2. Uses file upload for the TLS certificate fields. Also makes it
   explicit whether the install generates the certificate or the
   user supplies it. I used this change as an opportunity to move
   the generation of a cert into the `HelmChart` object.

3. Migrates the admin users and domain to a "Application Core"
   configuration group. I don't love the name, so would love
   additional suggestions there.

4. Breaks out TLS and Ingress options into their own groups for
   readablity. A bit of a personal preference to do it this way
   (kind of like the upload vs. textarea thing for the certs) but
   I feel like it breaks up the page a bit more and makes it
   friendlier.

5. Moves the database config to the bottom. It felt odd that the
   first thing I was asked for was how I wanted to handle the
   database. So I tried this instead.

The goal of these change is twofold: to improve the UX for a user
running an install with KOTS, and to show our vendors how the KOTS
config can be used to assert their opinons on configuration rather
than just parroting the Helm values.
