### PR TITLE
Slackernews Admin Console link

### DIFF
--- a/kots/application.yaml
+++ b/kots/application.yaml
@@ -21,3 +21,7 @@ spec:
       - src: "https://uploads-ssl.webflow.com/6310ad0e6a18aa1620da6ae8/6330e04f42bc6a7ba03b4725_snicon.png"
         type: "image/png"
     type: slackernews
+    links:
+      - description: 🔗 Open Slackernews
+        url: "http://slackernews"
+#      - description: Slackernews Admin

--- a/kots/replicated-app.yaml
+++ b/kots/replicated-app.yaml
@@ -9,10 +9,10 @@ spec:
   allowRollback: true
   minKotsVersion: 1.79.0
   ports:
-    - serviceName: web
-      servicePort: 80
-      localPort: 80
-      applicationUrl: "http://slackernews-nginx"
+    - serviceName: slackernews
+      servicePort: 3000
+      localPort: 3000
+      applicationUrl: "http://slackernews"
   statusInformers:
     - deployment/slackernews
     - '{{repl if ConfigOptionEquals "deploy_postgres" "1"}}statefulset/postgres{{repl end}}'


### PR DESCRIPTION
Fixes #37 

Got the port forward working locally 

<img width="702" alt="Screenshot 2024-01-15 at 8 46 28 PM" src="https://github.com/slackernews/slackernews/assets/3730605/b466d4fd-0340-4e06-8eba-796d2d4a86a1">

and in the kots admin console

<img width="574" alt="Screenshot 2024-01-15 at 8 46 16 PM" src="https://github.com/slackernews/slackernews/assets/3730605/43178ced-68f8-421f-8cc6-236ff7255140">


### But...

I'm not even sure if this is something we should include. Because the user will need to have it accessible at some public, well-TLS'd URL (e.g. ngrok), it doesn't *really* make sense to give them a path to use it via a port-forward on localhost:3000.

let's discuss