### PR TITLE
Fixes error when selecting `ClusterIP` service type

### DIFF
--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -32,8 +32,6 @@ spec:
         enabled: true
     nginx:
       enabled: true 
-      service:
-        type: repl{{ ConfigOption "service_type" }}
     images:
       pullSecrets:
         replicated:
@@ -54,6 +52,13 @@ spec:
       values:
         postgres:
           uri: '{{repl ConfigOption "postgres_external_uri" }}'
+
+    - when: '{{repl ConfigOptionEquals "service_type" "cluster_ip"}}'
+      recursiveMerge: true
+      values:
+        nginx:
+          service:
+            type: ClusterIP
 
     - when: '{{repl ConfigOptionEquals "service_type" "load_balancer"}}'
       recursiveMerge: true


### PR DESCRIPTION
TL;DR
-----

Correctly sets the Helm value when user chooses `ClusterIP`

Details
-------

Noticed a bug when I deployed with the `ClusterIP` service. I'd
changed the values for the various service type values in the
config to snake case, and that value was being passed on directly
when the selected type was `ClusterIP`. This change fixes that
bug.
