### PR TITLE
Uses EC 1.15.0+k8s-1.29

### DIFF
--- a/kots/embedded-cluster.yaml
+++ b/kots/embedded-cluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 1.9.1+k8s-1.29
+  version: 1.15.0+k8s-1.29
   unsupportedOverrides:
     k0s: |
       config:


### PR DESCRIPTION
TL;DR
-----

Bumps EC version

Details
-------

Upgrades the version of the Rplicated Embedded Cluster from 1.9.1 to
1.15.0. Contnutes with Kubernerts 1.29.
