### PR TITLE
Enables building and deploying using airgap features

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -54,16 +54,6 @@ jobs:
           cache-from: ${{ steps.cache.outputs.cache-from }}
           cache-to: ${{ steps.cache.outputs.cache-to }}
 
-      - name: Build nginx image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          tags: ${{ env.REGISTRY }}/${{ secrets.GHCR_NAMESPACE }}/slackernews-nginx:0.0.0-alpha.${{ steps.vars.outputs.sha_short }}
-          file: ./deploy/Dockerfile.nginx
-          push: true
-          cache-from: ${{ steps.cache.outputs.cache-from }}
-          cache-to: ${{ steps.cache.outputs.cache-to }}
-
   release:
     runs-on: ubuntu-22.04
     needs:
@@ -95,14 +85,6 @@ jobs:
           include: 'chart/slackernews/values.yaml'
           find: '$IMAGE'
           replace: 'proxy/${{ secrets.REPLICATED_APP }}/ghcr.io/${{ secrets.GHCR_NAMESPACE }}/slackernews-web:${{ steps.get_version.outputs.version-without-v }}'
-          regex: false
-
-      - name: Update the values.yaml with the nginx image path
-        uses: jacobtomlinson/gha-find-replace@v2
-        with:
-          include: 'chart/slackernews/values.yaml'
-          find: '$NGINX_IMAGE'
-          replace: 'proxy/${{ secrets.REPLICATED_APP }}/ghcr.io/${{ secrets.GHCR_NAMESPACE }}/slackernews-nginx:${{ steps.get_version.outputs.version-without-v }}'
           regex: false
 
       - id: package-helm-chart

--- a/chart/slackernews/templates/_helper.tpl
+++ b/chart/slackernews/templates/_helper.tpl
@@ -37,21 +37,22 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/*
 Image pull secrets
-*}}
+*/}}
 {{- define "slackernews.imagePullSecrets" -}}
   {{- $pullSecrets := list }}
 
-  {{/* use any global pull secrets */}}
-  {{- range ((.global).imagePullSecrets) -}}
-    {{- if kindIs "map" . -}}
-      {{- $pullSecrets = append $pullSecrets .name -}}
-    {{- else -}}
-      {{- $pullSecrets = append $pullSecrets . -}}
-    {{- end }}
+  {{- with ((.Values.global).imagePullSecrets) -}}
+    {{- range . -}}
+      {{- if kindIs "map" . -}}
+        {{- $pullSecrets = append $pullSecrets .name -}}
+      {{- else -}}
+        {{- $pullSecrets = append $pullSecrets . -}}
+      {{- end }}
+    {{- end -}}
   {{- end -}}
 
   {{/* use image pull secrets provided as values */}}
-  {{- range .images -}}
+  {{- with .Values.images -}}
     {{- range .pullSecrets -}}
       {{- if kindIs "map" . -}}
         {{- $pullSecrets = append $pullSecrets .name -}}
@@ -62,7 +63,7 @@ Image pull secrets
   {{- end -}}
 
   {{/* use secret created with injected docker config */}}
-  {{ if hasKey ((.Values.global).replicated) "dockerconfigjson" }}
+  {{- if hasKey ((.Values.global).replicated) "dockerconfigjson" }}
     {{- $pullSecrets = append $pullSecrets "slackernews-pull-secret" -}}
   {{- end -}}
 

--- a/chart/slackernews/templates/_helper.tpl
+++ b/chart/slackernews/templates/_helper.tpl
@@ -34,3 +34,43 @@ Selector labels
 app.kubernetes.io/name: {{ include "slackernews.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Image pull secrets
+*}}
+{{- define "slackernews.imagePullSecrets" -}}
+  {{- $pullSecrets := list }}
+
+  {{/* use any global pull secrets */}}
+  {{- range ((.global).imagePullSecrets) -}}
+    {{- if kindIs "map" . -}}
+      {{- $pullSecrets = append $pullSecrets .name -}}
+    {{- else -}}
+      {{- $pullSecrets = append $pullSecrets . -}}
+    {{- end }}
+  {{- end -}}
+
+  {{/* use image pull secrets provided as values */}}
+  {{- range .images -}}
+    {{- range .pullSecrets -}}
+      {{- if kindIs "map" . -}}
+        {{- $pullSecrets = append $pullSecrets .name -}}
+      {{- else -}}
+        {{- $pullSecrets = append $pullSecrets . -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{/* use secret created with injected docker config */}}
+  {{ if hasKey ((.Values.global).replicated) "dockerconfigjson" }}
+    {{- $pullSecrets = append $pullSecrets "slackernews-pull-secret" -}}
+  {{- end -}}
+
+
+  {{- if (not (empty $pullSecrets)) -}}
+imagePullSecrets:
+    {{- range $pullSecrets | uniq }}
+  - name: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/chart/slackernews/templates/imagepullsecret.yaml
+++ b/chart/slackernews/templates/imagepullsecret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: replicated-pull-secret
+  name: slackernews-pull-secret
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Values.global.replicated.dockerconfigjson }}

--- a/chart/slackernews/templates/nginx-deployment.yaml
+++ b/chart/slackernews/templates/nginx-deployment.yaml
@@ -13,7 +13,7 @@ spec:
         app: slackernews-nginx
     spec:
       containers:
-      - image: nginx:1.25.3
+      - image: {{ .Values.images.nginx.registry }}/{{ .Values.images.nginx.repository }}:{{ .Values.images.nginx.tag }}
         name: slackernews-nginx
         ports:
 {{ if .Values.service.tls.enabled }}

--- a/chart/slackernews/templates/nginx-deployment.yaml
+++ b/chart/slackernews/templates/nginx-deployment.yaml
@@ -12,6 +12,7 @@ spec:
       labels:
         app: slackernews-nginx
     spec:
+      {{- include "slackernews.imagePullSecrets" . | nindent 6 }}
       containers:
       - image: {{ .Values.images.nginx.registry }}/{{ .Values.images.nginx.repository }}:{{ .Values.images.nginx.tag }}
         name: slackernews-nginx

--- a/chart/slackernews/templates/postgres-statefulset.yaml
+++ b/chart/slackernews/templates/postgres-statefulset.yaml
@@ -26,7 +26,7 @@ spec:
               name: "{{ if .Values.postgres.existingSecretName }}{{ .Values.postgres.existingSecretName }}{{ else }}slackernews-postgres{{ end }}"
         - name: POSTGRES_DB
           value: slackernews
-        image: postgres:14
+        image: {[ .Values.images.postgres.registry }}/{{ .Values.images.postgres.repository }}:{{ .Values.images.postgres.tag }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/chart/slackernews/templates/postgres-statefulset.yaml
+++ b/chart/slackernews/templates/postgres-statefulset.yaml
@@ -27,7 +27,7 @@ spec:
               name: "{{ if .Values.postgres.existingSecretName }}{{ .Values.postgres.existingSecretName }}{{ else }}slackernews-postgres{{ end }}"
         - name: POSTGRES_DB
           value: slackernews
-        image: {[ .Values.images.postgres.registry }}/{{ .Values.images.postgres.repository }}:{{ .Values.images.postgres.tag }}
+        image: {{ .Values.images.postgres.registry }}/{{ .Values.images.postgres.repository }}:{{ .Values.images.postgres.tag }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/chart/slackernews/templates/postgres-statefulset.yaml
+++ b/chart/slackernews/templates/postgres-statefulset.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: postgres
     spec:
+      {{- include "slackernews.imagePullSecrets" . | nindent 6 }}
       containers:
       - env:
         - name: PGDATA

--- a/chart/slackernews/templates/slackernews-deployment.yaml
+++ b/chart/slackernews/templates/slackernews-deployment.yaml
@@ -14,10 +14,7 @@ spec:
       labels:
         app: slackernews
     spec:
-      {{ if hasKey ((.Values.global).replicated) "dockerconfigjson" }}
-      imagePullSecrets:
-        - name: replicated-pull-secret
-      {{ end }}
+      {{- include "slackernews.imagePullSecrets" . | nindent 6 }}
       containers:
       - image: {{ .Values.images.slackernews.registry }}/{{ .Values.images.slackernews.repository }}:{{ .Values.images.slackernews.tag }}
         imagePullPolicy: {{ .Values.images.slackernews.pullPolicy }}

--- a/chart/slackernews/templates/slackernews-deployment.yaml
+++ b/chart/slackernews/templates/slackernews-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: replicated-pull-secret
       {{ end }}
       containers:
-      - image: {{ .Values.images.slackernews.repository }}
+      - image: {{ .Values.images.slackernews.registry }}/{{ .Values.images.slackernews.repository }}:{{ .Values.images.slackernews.tag }}
         imagePullPolicy: {{ .Values.images.slackernews.pullPolicy }}
         name: slackernews
         env:

--- a/chart/slackernews/values.yaml
+++ b/chart/slackernews/values.yaml
@@ -66,3 +66,8 @@ images:
     repository: $IMAGE
     tag: $VERSION
     pullPolicy: IfNotPresent
+  postgres:
+    registry: index.docker.io
+    repository: library/postgres
+    tag: 14
+    pullPolicy: IfNotPresent

--- a/chart/slackernews/values.yaml
+++ b/chart/slackernews/values.yaml
@@ -53,9 +53,7 @@ replicated:
   isEmbeddedCluster: false
 
 images:
-  pullSecrets:
-    replicated:
-      name: proxypullsecret
+  pullSecrets: []
   slackernews:
     registry: $REGISTRY
     repository: $IMAGE

--- a/chart/slackernews/values.yaml
+++ b/chart/slackernews/values.yaml
@@ -57,7 +57,9 @@ images:
     replicated:
       name: proxypullsecret
   nginx:
-    repository: $REGISTRY/$NGINX_IMAGE
+    registry: index.docker.io
+    repository: library/nginx
+    tag: 1.25.3
     pullPolicy: IfNotPresent
   slackernews:
     repository: $REGISTRY/$IMAGE

--- a/chart/slackernews/values.yaml
+++ b/chart/slackernews/values.yaml
@@ -62,5 +62,7 @@ images:
     tag: 1.25.3
     pullPolicy: IfNotPresent
   slackernews:
-    repository: $REGISTRY/$IMAGE
+    registry: $REGISTRY
+    repository: $IMAGE
+    tag: $VERSION
     pullPolicy: IfNotPresent

--- a/chart/slackernews/values.yaml
+++ b/chart/slackernews/values.yaml
@@ -56,15 +56,15 @@ images:
   pullSecrets:
     replicated:
       name: proxypullsecret
-  nginx:
-    registry: index.docker.io
-    repository: library/nginx
-    tag: 1.25.3
-    pullPolicy: IfNotPresent
   slackernews:
     registry: $REGISTRY
     repository: $IMAGE
     tag: $VERSION
+    pullPolicy: IfNotPresent
+  nginx:
+    registry: index.docker.io
+    repository: library/nginx
+    tag: 1.25.3
     pullPolicy: IfNotPresent
   postgres:
     registry: index.docker.io

--- a/deploy/Dockerfile.nginx
+++ b/deploy/Dockerfile.nginx
@@ -1,2 +1,0 @@
-FROM nginx:1.25.3
-RUN apt-get update && apt-get install -y curl && apt-get clean

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -26,8 +26,6 @@ spec:
       enabled: false
     replicated:
       isEmbeddedCluster: repl{{ eq Distribution "embedded-cluster"}}
-      enabled: false
-      preflights: false
       isKOTSManaged: true
     service:
       tls:

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -39,12 +39,16 @@ spec:
           port: 443
     images:
       pullSecrets:
-        replicated:
-          dockerconfigjson: ""
+        - name: '{{repl ImagePullSecret }}'
       slackernews:
-        pullSecret: repl{{ ImagePullSecretName }}
-        repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/ghcr.io/$NAMESPACE" ) }}/slackernews-web:$VERSION'
-
+        registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
+        repository: '{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/ghcr.io/$NAMESPACE" ) }}/slackernews-web'
+      nginx:
+        registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
+        repository: '{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/index.docker.io/library" ) }}/nginx'
+      postgres:
+        registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
+        repository: '{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/index.docker.io/library" ) }}/postgres'
   optionalValues:
     - when: '{{repl ConfigOptionEquals "deploy_postgres" "1"}}'
       recursiveMerge: true

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -121,7 +121,21 @@ spec:
   # and manifests. this is used in replicated to create airgap packages
   builder:
     postgres:
-      password: repl{{ ConfigOption "postgres_password"}}
-    admin-console:
-      enabled: false
+      password: this-is-not-used-but-needed-for-builder
+      deploy_postgres: true
+      enabled: true
 
+    images:
+      slackernews:
+        registry: ghcr.io
+        repository: $NAMESPACE/slackernews-web
+      nginx:
+        registry: index.docker.io
+        repository: library/nginx
+      postgres:
+        registry: index.docker.io
+        repository: library/postgres
+    replicated:
+      image:
+        registry: index.docker.io
+        repository: replicated/replicated-sdk

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -27,6 +27,8 @@ spec:
     replicated:
       isEmbeddedCluster: repl{{ eq Distribution "embedded-cluster"}}
       isKOTSManaged: true
+      imagePullSecrets:
+        - name: '{{repl ImagePullSecretName }}'
       image:
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
         repository: '{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/index.docker.io/replicated" ) }}/replicated-sdk'

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -49,6 +49,10 @@ spec:
       postgres:
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
         repository: '{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/index.docker.io/library" ) }}/postgres'
+    replicated:
+      image:
+        registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
+        repository: '{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/index.docker.io/replicated" ) }}/replicated-sdk'
   optionalValues:
     - when: '{{repl ConfigOptionEquals "deploy_postgres" "1"}}'
       recursiveMerge: true
@@ -109,6 +113,12 @@ spec:
               {{repl $cert.Cert | nindent 14 }}
             key: |-
               {{repl $cert.Key | nindent 14 }}
+
+    - when: '{{repl HasLocalRegistry }}'
+      recursiveMerge: true
+      values:
+        replicated:
+          isAirgap: true
 
   # builder values provide a way to render the chart with all images
   # and manifests. this is used in replicated to create airgap packages

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -31,7 +31,7 @@ spec:
         - name: '{{repl ImagePullSecretName }}'
       image:
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
-        repository: '{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/index.docker.io/replicated" ) }}/replicated-sdk'
+        repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/index.docker.io/replicated" ) }}/replicated-sdk'
     service:
       tls:
         enabled: true
@@ -45,13 +45,13 @@ spec:
         - name: '{{repl ImagePullSecretName }}'
       slackernews:
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
-        repository: '{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/ghcr.io/$NAMESPACE" ) }}/slackernews-web'
+        repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/ghcr.io/$NAMESPACE" ) }}/slackernews-web'
       nginx:
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
-        repository: '{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/index.docker.io/library" ) }}/nginx'
+        repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/index.docker.io/library" ) }}/nginx'
       postgres:
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
-        repository: '{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/index.docker.io/library" ) }}/postgres'
+        repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/index.docker.io/library" ) }}/postgres'
   optionalValues:
     - when: '{{repl ConfigOptionEquals "deploy_postgres" "1"}}'
       recursiveMerge: true

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -50,7 +50,6 @@ spec:
       postgres:
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
         repository: '{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/index.docker.io/library" ) }}/postgres'
-    replicated:
   optionalValues:
     - when: '{{repl ConfigOptionEquals "deploy_postgres" "1"}}'
       recursiveMerge: true

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -40,7 +40,7 @@ spec:
           port: 443
     images:
       pullSecrets:
-        - name: '{{repl ImagePullSecret }}'
+        - name: '{{repl ImagePullSecretName }}'
       slackernews:
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
         repository: '{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/ghcr.io/$NAMESPACE" ) }}/slackernews-web'

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -27,6 +27,9 @@ spec:
     replicated:
       isEmbeddedCluster: repl{{ eq Distribution "embedded-cluster"}}
       isKOTSManaged: true
+      image:
+        registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
+        repository: '{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/index.docker.io/replicated" ) }}/replicated-sdk'
     service:
       tls:
         enabled: true
@@ -48,9 +51,6 @@ spec:
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
         repository: '{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/index.docker.io/library" ) }}/postgres'
     replicated:
-      image:
-        registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
-        repository: '{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/index.docker.io/replicated" ) }}/replicated-sdk'
   optionalValues:
     - when: '{{repl ConfigOptionEquals "deploy_postgres" "1"}}'
       recursiveMerge: true


### PR DESCRIPTION
TL;DR
-----

Allows Slackernews to build and deploy with airgap support

Details
-------

Updates the Slackernews chart and KOTS configuration so that it can be
deployed using KOTS, EC, and Helm airgap capabilities. It seems odd to talk
about deploying an application depending on access to Slack as an air-gapped
application, but that thinking doesn't take into account the use case that our
airgap support also enables: 

1. Deploying into a network that limits access to outside image registries
2. Security requirements that specify that images must be pulled from an
   internal registry
3. Security policy requiring images to be scanned before deployment, which is
   often accomplished using an internal registry

With this change, Slackernews can be deployed either with EC or KOTS airgap
bundles or using the enterprise portal instructions for Helm airgap.
