### PR TITLE
Fixes bug that always sets the nodeport port

### DIFF
--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -37,9 +37,6 @@ spec:
         enabled: true
     nginx:
       enabled: true
-      service:
-        nodePort:
-          port: 443
     images:
       pullSecrets:
         - name: '{{repl ImagePullSecretName }}'


### PR DESCRIPTION
TL;DR
-----

Moves node port port setting from values to optional values

Details
-------

Repairs a defect in the KOTS `HelmChart` where the value for
`nginx.service.nodePort.port` was always set, causing a failure for
other service types. That values is now only set when the service type
is node port.
