### PR TITLE
Uses newer EC version to avoid bugs

### DIFF
--- a/kots/embedded-cluster.yaml
+++ b/kots/embedded-cluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 1.15.0+k8s-1.29
+  version: 1.16.0+k8s-1.30
   unsupportedOverrides:
     k0s: |
       config:


### PR DESCRIPTION
TL;DR
-----

Switches to latest EC release

Details
-------

Adopts EC version 1.16.0+k8s.1.30 to avoid the pulled release that were
were using previously.
