### PR TITLE
Uses the Replicated Proxy Registry for all images

### DIFF
--- a/chart/slackernews/values.yaml
+++ b/chart/slackernews/values.yaml
@@ -53,19 +53,20 @@ replicated:
   isEmbeddedCluster: false
 
 images:
-  pullSecrets: []
+  pullSecrets:
+    - name: slackernews-pull-secret
   slackernews:
     registry: $REGISTRY
     repository: $IMAGE
     tag: $VERSION
     pullPolicy: IfNotPresent
   nginx:
-    registry: index.docker.io
-    repository: library/nginx
+    registry: $REGISTRY
+    repository: proxy/anonymous/library/nginx
     tag: 1.25.3
     pullPolicy: IfNotPresent
   postgres:
-    registry: index.docker.io
-    repository: library/postgres
+    registry: $REGISTRY
+    repository: proxy/anonymous/library/postgres
     tag: 14
     pullPolicy: IfNotPresent

--- a/chart/slackernews/values.yaml
+++ b/chart/slackernews/values.yaml
@@ -53,7 +53,7 @@ replicated:
   isEmbeddedCluster: false
   image:
     registry: $REGISTRY
-    repository: anonymous/index.docker.io/replicated/replicated-sdk"
+    repository: anonymous/index.docker.io/replicated/replicated-sdk
 
 images:
   pullSecrets:

--- a/chart/slackernews/values.yaml
+++ b/chart/slackernews/values.yaml
@@ -51,6 +51,9 @@ slackernews:
 
 replicated:
   isEmbeddedCluster: false
+  image:
+    registry: $REGISTRY
+    repository: anonymous/index.docker.io/replicated/replicated-sdk"
 
 images:
   pullSecrets:

--- a/chart/slackernews/values.yaml
+++ b/chart/slackernews/values.yaml
@@ -62,11 +62,11 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     registry: $REGISTRY
-    repository: proxy/anonymous/index.docker.io/library/nginx
+    repository: anonymous/index.docker.io/library/nginx
     tag: 1.25.3
     pullPolicy: IfNotPresent
   postgres:
     registry: $REGISTRY
-    repository: proxy/anonymous/index.docker.io/library/postgres
+    repository: anonymous/index.docker.io/library/postgres
     tag: 14
     pullPolicy: IfNotPresent

--- a/chart/slackernews/values.yaml
+++ b/chart/slackernews/values.yaml
@@ -62,11 +62,11 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     registry: $REGISTRY
-    repository: proxy/anonymous/library/nginx
+    repository: proxy/anonymous/index.docker.io/library/nginx
     tag: 1.25.3
     pullPolicy: IfNotPresent
   postgres:
     registry: $REGISTRY
-    repository: proxy/anonymous/library/postgres
+    repository: proxy/anonymous/index.docker.io/library/postgres
     tag: 14
     pullPolicy: IfNotPresent

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -123,18 +123,3 @@ spec:
       password: this-is-not-used-but-needed-for-builder
       deploy_postgres: true
       enabled: true
-
-    images:
-      slackernews:
-        registry: ghcr.io
-        repository: $NAMESPACE/slackernews-web
-      nginx:
-        registry: index.docker.io
-        repository: library/nginx
-      postgres:
-        registry: index.docker.io
-        repository: library/postgres
-    replicated:
-      image:
-        registry: index.docker.io
-        repository: replicated/replicated-sdk


### PR DESCRIPTION
TL;DR
-----

Follows new guidance and default to the proxy regsitry

Details
-------

Adopts our new recommendation to use the proxy registry as the default
for all images directly in the Helm chart. It uses the proxy's anonymous
capabilities for the NGINX and Postgres images, while it's application
specific for the Slackernews image.

Also specifies the required image pull secret. This means the chart will
only be usable when pulled/installed from Replicated.
