### PR TITLE
Bumps Embedded Cluster version

### DIFF
--- a/kots/embedded-cluster.yaml
+++ b/kots/embedded-cluster.yaml
@@ -1,11 +1,4 @@
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 1.19.0+k8s-1.30
-  unsupportedOverrides:
-    k0s: |
-      config:
-        spec:
-          api:
-            extraArgs:
-              service-node-port-range: 80-32767
+  version: 2.1.3-k8s-1.29

--- a/kots/embedded-cluster.yaml
+++ b/kots/embedded-cluster.yaml
@@ -1,4 +1,4 @@
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 2.1.3-k8s-1.29
+  version: 2.1.3+k8s-1.29


### PR DESCRIPTION
TL;DR
-----

Upgrades to Embeded Cluster 2.x

Details
-------

Uses a new version of the Embedded Cluster, but keeps the Kubernetes
revision one behind the latest we support. This will let someone doing a
demo do a release that bumps Kubernets and show how that process works.
