### PR TITLE
Times out HTTP collectors

### DIFF
--- a/chart/slackernews/templates/preflights.yaml
+++ b/chart/slackernews/templates/preflights.yaml
@@ -18,18 +18,21 @@ stringData:
             collectorName: slack
             get:
               url: https://api.slack.com/methods/api.test
+              timeout: 2m
         - http:
             collectorName: helmValuesSlackUserToken
             post:
               url: https://slack.com/api/auth.test
               headers:
                 Authorization: Bearer {{.Values.slack.userToken}}
+              timeout: 2m
         - http:
             collectorName: helmValuesSlackBotToken
             post:
               url: https://slack.com/api/auth.test
               headers:
                 Authorization: Bearer {{.Values.slack.botToken}}
+              timeout: 2m
       analyzers:
         - clusterVersion:
             exclude: {{ eq .Values.replicated.isEmbeddedCluster true }}

--- a/chart/slackernews/templates/support-bundle.yaml
+++ b/chart/slackernews/templates/support-bundle.yaml
@@ -19,19 +19,21 @@ stringData:
             collectorName: slack
             get:
               url: https://api.slack.com/methods/api.test
+              timeout: 90s
         - http:
             collectorName: helmValuesSlackUserToken
             post:
               url: https://slack.com/api/auth.test
               headers:
                 Authorization: Bearer {{.Values.slack.userToken}}
+              timeout: 90s
         - http:
             collectorName: helmValuesSlackBotToken
             post:
               url: https://slack.com/api/auth.test
               headers:
                 Authorization: Bearer {{.Values.slack.botToken}}
-
+              timeout: 90s
         - logs:
             namespace: {{ .Release.Namespace }}
             selector:


### PR DESCRIPTION
TL;DR
-----

Adds a time out to HTTP collectors in preflights/support bundles

Details
-------

Sets a timeout of 90 seconds on the HTTP colelctors that connect to
Slack in the preflights and support bundles. They were timing out
whenever Go defaults, which, while not actually forever, is effectively
so.
