### PR TITLE
Cleans up image handling post-SecureBuild

### DIFF
--- a/chart/slackernews/templates/preflights.yaml
+++ b/chart/slackernews/templates/preflights.yaml
@@ -18,21 +18,21 @@ stringData:
             collectorName: slack
             get:
               url: https://api.slack.com/methods/api.test
-              timeout: 2m
+              timeout: 20s
         - http:
             collectorName: helmValuesSlackUserToken
             post:
               url: https://slack.com/api/auth.test
               headers:
                 Authorization: Bearer {{.Values.slack.userToken}}
-              timeout: 2m
+              timeout: 20s
         - http:
             collectorName: helmValuesSlackBotToken
             post:
               url: https://slack.com/api/auth.test
               headers:
                 Authorization: Bearer {{.Values.slack.botToken}}
-              timeout: 2m
+              timeout: 20s
       analyzers:
         - clusterVersion:
             exclude: {{ eq .Values.replicated.isEmbeddedCluster true }}

--- a/chart/slackernews/values.yaml
+++ b/chart/slackernews/values.yaml
@@ -53,7 +53,7 @@ replicated:
   isEmbeddedCluster: false
   image:
     registry: $REGISTRY
-    repository: proxy.replicated.com/library/replicated-sdk-image
+    repository: library/replicated-sdk-image
     tag: 1.7.0
 
 images:

--- a/kots/embedded-cluster.yaml
+++ b/kots/embedded-cluster.yaml
@@ -1,4 +1,4 @@
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 2.7.2+k8s-1.31
+  version: 2.7.4+k8s-1.31

--- a/kots/embedded-cluster.yaml
+++ b/kots/embedded-cluster.yaml
@@ -1,4 +1,4 @@
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 2.7.2+k8s-1.27
+  version: 2.7.2+k8s-1.31

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -40,13 +40,13 @@ spec:
         - name: '{{repl ImagePullSecretName }}'
       slackernews:
         registry: '$REGISTRY'
-        repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/$NAMESPACE"/slackernews-web'
+        repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/$NAMESPACE/slackernews-web'
       nginx:
         registry: '$REGISTRY'
-        repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/cve0.io"/nginx'
+        repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/cve0.io/nginx'
       postgres:
         registry: '$REGISTRY'
-        repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/cve0.io"/postgres'
+        repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/cve0.io/postgres'
 
   optionalValues:
     # load images from the local registry in an airgapped environment

--- a/kots/slackernews-chart.yaml
+++ b/kots/slackernews-chart.yaml
@@ -30,9 +30,6 @@ spec:
       isKOTSManaged: true
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
-      image:
-        registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
-        repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace "library/replicated-sdk-image"}}'
     service:
       tls:
         enabled: true
@@ -42,27 +39,77 @@ spec:
       pullSecrets:
         - name: '{{repl ImagePullSecretName }}'
       slackernews:
-        registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
-        repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/ghcr.io/$NAMESPACE" ) }}/slackernews-web'
+        registry: '$REGISTRY'
+        repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/$NAMESPACE"/slackernews-web'
       nginx:
-        registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
-        repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/cve0.io" ) }}/nginx'
+        registry: '$REGISTRY'
+        repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/cve0.io"/nginx'
       postgres:
-        registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "$REGISTRY" }}'
-        repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/cve0.io" ) }}/postgres'
+        registry: '$REGISTRY'
+        repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/cve0.io"/postgres'
+
   optionalValues:
+    # load images from the local registry in an airgapped environment
+    - when: '{{repl HasLocalRegistry }}'
+      recursiveMerge: true
+      values:
+        replicated:
+          isAirgap: true
+          image:
+            registry: '{{repl LocalRegistryHost }}'
+            repository: '{{repl LocalRegistryNamespace }}/replicated-sdk-image'
+        slackernews:
+          registry: '{{repl LocalRegistryHost}}'
+          repository: '{{LocalRegistryNamespace}}/slackernews-web'
+        nginx:
+          registry: '{{repl LocalRegistryHost}}'
+          repository: '{{LocalRegistryNamespace}}/nginx'
+        postgres:
+          registry: '{{repl LocalRegistryHost}}'
+          repository: '{{LocalRegistryNamespace}}/postgres'
+
+    # the user wants us to deploy a local Postgres instance
     - when: '{{repl ConfigOptionEquals "deploy_postgres" "1"}}'
       recursiveMerge: true
       values:
         postgres:
           password: '{{repl ConfigOption "postgres_password" }}'
 
+    # the user provided their own Postgres instance
     - when: '{{repl ConfigOptionEquals "deploy_postgres" "0"}}'
       recursiveMerge: true
       values:
         postgres:
           uri: '{{repl ConfigOption "postgres_external_uri" }}'
 
+    # use the user-provided certificates 
+    - when: '{{repl ConfigOptionEquals "certificate_source" "upload_existing"}}'
+      recursiveMerge: true
+      values:
+        service:
+          tls:
+            enabled: true
+            cert: repl{{ ConfigOptionData "tls_cert" | nindent 14 }}
+            key: repl{{ ConfigOptionData "tls_key" | nindent 14 }}
+            ca: repl{{ ConfigOptionData "tls_ca" | nindent 14 }}
+          
+    # or generate our own
+    - when: '{{repl ConfigOptionEquals "certificate_source" "generate_internal"}}'
+      recursiveMerge: true
+      values:
+        service:
+          tls:
+            enabled: true
+            ca: |-
+              {{repl $ca := genCA (LicenseFieldValue "customerName") 365 }}
+              {{repl $ca.Cert | Base64Encode}}
+            cert: |-
+              {{repl $cert := genSignedCert (ConfigOption "slackernews_domain") nil (list (ConfigOption "slackernews_domain")) 365 $ca }}
+              {{repl $cert.Cert | nindent 14 }}
+            key: |-
+              {{repl $cert.Key | nindent 14 }}
+             
+    # handle different service types
     - when: '{{repl ConfigOptionEquals "service_type" "cluster_ip"}}'
       recursiveMerge: true
       values:
@@ -86,36 +133,7 @@ spec:
             nodePort:
               port: repl{{ ConfigOption "node_port_port" }}
 
-    - when: '{{repl ConfigOptionEquals "certificate_source" "upload_existing"}}'
-      recursiveMerge: true
-      values:
-        service:
-          tls:
-            enabled: true
-            cert: repl{{ ConfigOptionData "tls_cert" | nindent 14 }}
-            key: repl{{ ConfigOptionData "tls_key" | nindent 14 }}
-            ca: repl{{ ConfigOptionData "tls_ca" | nindent 14 }}
 
-    - when: '{{repl ConfigOptionEquals "certificate_source" "generate_internal"}}'
-      recursiveMerge: true
-      values:
-        service:
-          tls:
-            enabled: true
-            ca: |-
-              {{repl $ca := genCA (LicenseFieldValue "customerName") 365 }}
-              {{repl $ca.Cert | Base64Encode}}
-            cert: |-
-              {{repl $cert := genSignedCert (ConfigOption "slackernews_domain") nil (list (ConfigOption "slackernews_domain")) 365 $ca }}
-              {{repl $cert.Cert | nindent 14 }}
-            key: |-
-              {{repl $cert.Key | nindent 14 }}
-
-    - when: '{{repl HasLocalRegistry }}'
-      recursiveMerge: true
-      values:
-        replicated:
-          isAirgap: true
 
   # builder values provide a way to render the chart with all images
   # and manifests. this is used in replicated to create airgap packages


### PR DESCRIPTION
TL;DR
-----

Improves application reliability by reducing API timeout thresholds from 2 minutes to 20 seconds for preflight checks and updates dependency versions for better compatibility.

Details
--------

Addresses several operational issues with deployment configurations that were causing unnecessary delays and compatibility problems:

1. The previous 2-minute timeout for Slack API connectivity checks was excessive and could lead to unnecessarily long installation experiences. By reducing these timeouts to 20 seconds, we allow failures to be detected faster while still providing ample time for successful API connections.

2. Updates the embedded cluster Kubernetes version from 2.7.2+k8s-1.27 to 2.7.4+k8s-1.31 to take advantage of the latest security and performance improvements.

3. Simplifies the image repository configuration by removing unnecessary conditional logic in the Helm chart. The new approach uses a more direct reference to image locations while still maintaining proper support for airgapped environments through the optional values section.

4. Reorganizes and adds comments to the KOTS configuration file to improve readability and maintainability, making it easier for administrators to understand the available deployment options.

These changes collectively improve the installation experience, reduce unnecessary wait times during preflight checks, and ensure compatibility with the latest supported infrastructure components.
