### PR TITLE
Uses Debian builder for proper native library support

### DIFF
--- a/deploy/Dockerfile.web
+++ b/deploy/Dockerfile.web
@@ -1,8 +1,12 @@
 # Use a specific version of node:alpine as the base image
-FROM node:20-alpine AS base
+FROM node:20-bookworm-slim AS base
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    python3 \
+    libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install dependencies that might be necessary
-RUN ["apk", "add", "--no-cache", "libc6-compat"]
 WORKDIR /app
 
 # Install dependencies based on the lock file present


### PR DESCRIPTION
TL;DR
-----

Fixes bug with SQLite native libraries

Details
-------

Corrects a defect where the SQLite libraries were not loading correctly in our SecureBuild-based image. The builder layers we used were Alpine-based, which lead to an incompatibility with the underlying SQLite library's native code. This led to a runtime exception and `500` errors all around. The new build-layers are Debian based and avoid the issue.
