### PR TITLE
fix: replace broken semver-cli with Node.js semver package

### DIFF
--- a/.github/workflows/update-embedded-cluster.yml
+++ b/.github/workflows/update-embedded-cluster.yml
@@ -1,0 +1,75 @@
+name: Update Embedded Cluster Version
+
+on:
+  schedule:
+    - cron: '0 8 * * *'  # Run daily at 8 AM UTC
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  check-and-update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Setup yq
+        id: current
+        uses: mikefarah/yq@master
+        with:
+          cmd: |
+            yq '.spec.version' kots/embedded-cluster.yaml
+      
+      - name: Get latest release
+        id: latest
+        run: |
+          LATEST=$(curl -s https://api.github.com/repos/replicatedhq/embedded-cluster/releases/latest | jq -r .tag_name)
+          echo "version=$LATEST" >> $GITHUB_OUTPUT
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      
+      - name: Install semver package
+        run: npm install -g semver
+      
+      - name: Compare versions and update
+        id: compare
+        run: |
+          CURRENT="${{ steps.current.outputs.result }}"
+          LATEST="${{ steps.latest.outputs.version }}"
+          
+          # Check if latest is greater than current
+          if npx semver -r ">$CURRENT" $LATEST >/dev/null 2>&1; then
+            CURRENT_MAJOR=$(npx semver $CURRENT | cut -d. -f1)
+            if npx semver -r "~$CURRENT_MAJOR" $LATEST >/dev/null 2>&1; then
+              # Update the file using yq
+              yq -i '.spec.version = "${{ steps.latest.outputs.version }}"' kots/embedded-cluster.yaml
+              echo "needs_update=true" >> $GITHUB_OUTPUT
+            else
+              echo "needs_update=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "needs_update=false" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Create Pull Request
+        if: steps.compare.outputs.needs_update == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "build: update embedded-cluster to ${{ steps.latest.outputs.version }}"
+          title: "Update embedded-cluster to ${{ steps.latest.outputs.version }}"
+          body: |
+            This PR updates the embedded-cluster version from `${{ steps.current.outputs.result }}` to `${{ steps.latest.outputs.version }}`.
+            
+            Changes:
+            - Updated `kots/embedded-cluster.yaml` with the latest version
+            
+            🤖 Generated with [Claude Code](https://claude.ai/code)
+          branch: update-embedded-cluster-${{ steps.latest.outputs.version }}
+          delete-branch: true

--- a/.github/workflows/update-embedded-cluster.yml
+++ b/.github/workflows/update-embedded-cluster.yml
@@ -61,7 +61,7 @@ jobs:
         if: steps.compare.outputs.needs_update == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTO_PR_TOKEN || secrets.GITHUB_TOKEN }}
           commit-message: "build: update embedded-cluster to ${{ steps.latest.outputs.version }}"
           title: "Update embedded-cluster to ${{ steps.latest.outputs.version }}"
           body: |


### PR DESCRIPTION
## Summary
- Fixes the failing "Update Embedded Cluster Version" workflow
- Replaces broken semver-cli binary download with Node.js semver package

## Problem
The workflow has been failing consistently for the past 10 days because it tries to download a semver-cli binary from:
```
https://github.com/davidrjonas/semver-cli/releases/latest/download/semver-linux-amd64
```

This URL returns a 404 error because the semver-cli project no longer provides precompiled binaries.

## Solution
- Replaced the semver-cli installation step with Node.js setup and semver package installation
- Updated the version comparison logic to use `npx semver` instead of the semver-cli commands
- This is more reliable since GitHub Actions runners come with Node.js pre-installed

## Test plan
- [x] Workflow syntax is valid
- [x] Successfully pushed changes to branch
- [ ] Manual workflow run to verify it works

🤖 Generated with [Claude Code](https://claude.ai/code)